### PR TITLE
Added General User Data - Have baseline 'general user data' endpoint working

### DIFF
--- a/devsite/requirements.txt
+++ b/devsite/requirements.txt
@@ -12,6 +12,9 @@
 python-dateutil==2.1
 path.py==8.2.1
 
+# Yes, this is old but is the one specified by Ginkgo edx-platform
+pytz==2016.7
+
 ##
 ## Django package dependencies
 ##

--- a/figures/filters.py
+++ b/figures/filters.py
@@ -129,3 +129,29 @@ class SiteDailyMetricsFilter(django_filters.FilterSet):
     class Meta:
         model = SiteDailyMetrics
         fields = ['date_for', 'date']
+
+
+class GeneralUserDataFilter(django_filters.FilterSet):
+
+    course_id = django_filters.MethodFilter(action='filter_course_id')
+
+    class Meta:
+        model = get_user_model()
+        fields = ['course_id', ]
+
+    def filter_course_id(self, queryset, course_id_str):
+        '''
+
+        This method converts the course id string to a CourseLocator object
+        and returns the filtered queryset. This is required because
+        CourseEnrollment course_id fields are of type CourseKeyField
+
+        Query parameters with plus signs '+' in the string are automatically
+        replaced with spaces, so we need to put the '+' back in for CourseKey
+        to be able to create a course key object from the string
+        '''
+        course_key = CourseKey.from_string(course_id_str.replace(' ', '+'))
+        # get course enrollments for the course
+        user_ids = CourseEnrollment.objects.filter(
+            course_id=course_key).values_list('user__id', flat=True).distinct()
+        return queryset.filter(id__in=user_ids)

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -11,9 +11,9 @@ from openedx.core.djangoapps.content.course_overviews.models import (
 
 from student.models import CourseEnrollment
 
-from .models import CourseDailyMetrics, SiteDailyMetrics
+from figures.helpers import as_course_key
+from figures.models import CourseDailyMetrics, SiteDailyMetrics
 
-from .helpers import as_course_key
 
 ##
 ## Serializer Field classes

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -2,6 +2,7 @@
 
 '''
 
+from django_countries import Countries
 from rest_framework import serializers
 
 from openedx.core.djangoapps.content.course_overviews.models import (
@@ -11,6 +12,33 @@ from openedx.core.djangoapps.content.course_overviews.models import (
 from student.models import CourseEnrollment
 
 from .models import CourseDailyMetrics, SiteDailyMetrics
+
+from .helpers import as_course_key
+
+##
+## Serializer Field classes
+##
+
+class SerializeableCountryField(serializers.ChoiceField):
+    '''
+    This class addresses an issue with django_countries that does not serialize
+    blank country values. See here:
+
+        https://github.com/SmileyChris/django-countries/issues/106
+    '''
+    def __init__(self, **kwargs):
+        super(SerializeableCountryField, self).__init__(choices=Countries(),
+            **kwargs)
+
+    def to_representation(self, value):
+        if value in ('', None):
+            # normally here it would return value.
+            # which is Country(u'') and not serialiable
+            # See the issue linked in the class docstring
+            return ''
+
+        return super(SerializeableCountryField, self).to_representation(value)
+
 
 ###
 ### Summary serializers for listing
@@ -82,3 +110,70 @@ class SiteDailyMetricsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = SiteDailyMetrics
+
+
+##
+## Serializers for serving the front end views
+##
+
+class GeneralUserDataSerializer(serializers.Serializer):
+    '''
+
+    Example from API docs:
+     {
+        "username": "maxi",
+        "country": "UY",
+        "is_active": true,
+        "year_of_birth": 1985,
+        "level_of_education": "b",
+        "gender": "m",
+        "date_joined": "2018-05-06T14:01:58Z",
+        "language_proficiencies": [],
+        "courses": [
+          {
+            "course_name": "Something",
+            "course_id": "A193+2016Q4+something",
+          }
+          ...
+        ]
+      },
+
+    Changes from spec:
+    courses list:
+    - uses 'id' instead of 'course_id'
+    - includes additional fields, org and number, as we are reusing the 
+    CourseIndexSerializer
+    '''
+
+    id = serializers.IntegerField(read_only=True)
+    username = serializers.CharField(read_only=True)
+    fullname = serializers.CharField(source='profile.name', default=None,
+        read_only=True)
+
+    country = SerializeableCountryField(source='profile.country',
+        required=False, read_only=True, allow_blank=True)
+    is_active = serializers.BooleanField(read_only=True)
+    year_of_birth = serializers.IntegerField(source='profile.year_of_birth', read_only=True)
+    gender = serializers.CharField(source='profile.gender', read_only=True)
+    date_joined = serializers.DateTimeField(format="%Y-%m-%d", read_only=True)
+    level_of_education = serializers.CharField(source='profile.level_of_education', 
+        allow_blank=True, required=False, read_only=True)
+
+    language_proficiencies = serializers.SerializerMethodField()
+    courses = serializers.SerializerMethodField()
+
+    def get_language_proficiencies(self, user):
+        if hasattr(user,'profiles') and user.profile.language:
+            return [user.profile.language]
+        else:
+            return []
+
+    def get_courses(self, user):
+        course_ids = CourseEnrollment.objects.filter(
+            user=user).values_list('course_id', flat=True).distinct()
+
+        course_overviews = CourseOverview.objects.filter(
+            id__in=[as_course_key(course_id) for course_id in course_ids])
+
+        return [CourseOverviewSerializer(data).data for data in course_overviews]
+

--- a/figures/urls.py
+++ b/figures/urls.py
@@ -27,6 +27,12 @@ router.register(
     views.CourseEnrollmentViewSet,
     base_name='course-enrollments')
 
+# For the front end UI
+router.register(
+    r'users/general',
+    views.GeneralUserDataViewSet,
+    base_name='general-users')
+
 
 urlpatterns = [
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,6 +12,7 @@ import datetime
 from django.contrib.auth import get_user_model
 #from django_countries.fields import CountryField
 import factory
+from factory import fuzzy
 from factory.django import DjangoModelFactory
 
 from openedx.core.djangoapps.content.course_overviews.models import (
@@ -60,7 +61,11 @@ class UserProfileFactory(DjangoModelFactory):
     # User full name
     name = factory.Sequence(lambda n: 'User Name{}'.format(n))
     country = 'US'
-
+    gender = 'o'
+    year_of_birth = fuzzy.FuzzyInteger(1950,2000)
+    level_of_education = fuzzy.FuzzyChoice(
+        ['p','m','b','a','hs','jh','el','none', 'other',]
+        )
 
 class UserFactory(DjangoModelFactory):
     class Meta:
@@ -70,6 +75,9 @@ class UserFactory(DjangoModelFactory):
     password = factory.PostGenerationMethodCall('set_password', 'password')
     is_active = True
     is_staff = False
+    is_superuser = False
+    date_joined = fuzzy.FuzzyDateTime(datetime.datetime(
+        2018,04,01, tzinfo=factory.compat.UTC))
 
     # TODO: Figure out if this can be a SubFactory and the advantages
     profile = factory.RelatedFactory(UserProfileFactory, 'user')

--- a/tests/mocks/student/models.py
+++ b/tests/mocks/student/models.py
@@ -1,7 +1,10 @@
 
+from datetime import datetime
+from pytz import UTC
 
 from django.db import models
 from django.contrib.auth.models import User
+from django.utils.translation import ugettext_noop
 
 from django_countries.fields import CountryField
 
@@ -14,6 +17,43 @@ class UserProfile(models.Model):
     user = models.OneToOneField(User, unique=True, db_index=True, related_name='profile')
     name = models.CharField(blank=True, max_length=255, db_index=True)
     country = CountryField(blank=True, null=True)
+
+    # Optional demographic data we started capturing from Fall 2012
+    this_year = datetime.now(UTC).year
+    VALID_YEARS = range(this_year, this_year - 120, -1)
+    year_of_birth = models.IntegerField(blank=True, null=True, db_index=True)
+
+    GENDER_CHOICES = (
+        ('m', ugettext_noop('Male')),
+        ('f', ugettext_noop('Female')),
+        # Translators: 'Other' refers to the student's gender
+        ('o', ugettext_noop('Other/Prefer Not to Say'))
+    )
+    gender = models.CharField(
+        blank=True, null=True, max_length=6, db_index=True, choices=GENDER_CHOICES
+    )
+
+    # [03/21/2013] removed these, but leaving comment since there'll still be
+    # p_se and p_oth in the existing data in db.
+    # ('p_se', 'Doctorate in science or engineering'),
+    # ('p_oth', 'Doctorate in another field'),
+    LEVEL_OF_EDUCATION_CHOICES = (
+        ('p', ugettext_noop('Doctorate')),
+        ('m', ugettext_noop("Master's or professional degree")),
+        ('b', ugettext_noop("Bachelor's degree")),
+        ('a', ugettext_noop("Associate degree")),
+        ('hs', ugettext_noop("Secondary/high school")),
+        ('jhs', ugettext_noop("Junior secondary/junior high/middle school")),
+        ('el', ugettext_noop("Elementary/primary school")),
+        # Translators: 'None' refers to the student's level of education
+        ('none', ugettext_noop("No formal education")),
+        # Translators: 'Other' refers to the student's level of education
+        ('other', ugettext_noop("Other education"))
+    )
+    level_of_education = models.CharField(
+        blank=True, null=True, max_length=6, db_index=True,
+        choices=LEVEL_OF_EDUCATION_CHOICES
+    )
 
 
 class CourseEnrollment(models.Model):

--- a/tests/views/test_general_user_data_view.py
+++ b/tests/views/test_general_user_data_view.py
@@ -1,0 +1,168 @@
+'''Tests Figures UserIndexView class
+
+TODO: make reasonable endpoint
+
+
+Front end expects data to be returned in the following form:
+
+[
+  {
+    "username": "maxi",
+    "country": "UY",
+    "is_active": true,
+    "year_of_birth": 1985,
+    "level_of_education": "b",
+    "gender": "m",
+    "date_joined": "2018-05-06T14:01:58Z",
+    "language_proficiencies": [],
+    "courses": [
+      {
+        "course_name": "Something",
+        "course_id": "A193+2016Q4+something",
+      }
+      ...
+    ]
+  },
+  ...
+]
+
+
+'''
+
+import pytest
+
+from django.contrib.auth import get_user_model
+from django.db.models import F
+
+from rest_framework.test import (
+    APIRequestFactory,
+    #RequestsClient, Not supported in older  rest_framework versions
+    force_authenticate,
+    )
+
+from student.models import CourseEnrollment
+
+from figures.views import (
+    GeneralUserDataViewSet,
+    )
+
+from tests.factories import (
+    CourseEnrollmentFactory,
+    CourseOverviewFactory,
+    UserFactory,
+    )
+
+COURSE_ID_STR_TEMPLATE = 'course-v1:StarFleetAcademy+SFA{}+2161'
+
+USER_DATA = [
+    {'id': 1, 'username': u'alpha', 'fullname': u'Alpha One',
+     'is_active': True, 'country': 'CA'},
+    {'id': 2, 'username': u'alpha02', 'fullname': u'Alpha Two', 'is_active': False, 'country': 'UK'},
+    {'id': 3, 'username': u'bravo', 'fullname': u'Bravo One', 'is_active': True, 'country': 'US'},
+    {'id': 4, 'username': u'bravo02', 'fullname': u'Bravo Two', 'is_active': True, 'country': 'UY'},
+]
+
+COURSE_DATA = [
+    { 'id': u'course-v1:AlphaOrg+A001+RUN', 'name': u'Alpha Course 1', 'org': u'AlphaOrg', 'number': u'A001' },
+    { 'id': u'course-v1:AlphaOrg+A002+RUN', 'name': u'Alpha Course 2', 'org': u'AlphaOrg', 'number': u'A002' },
+    { 'id': u'course-v1:BravoOrg+A001+RUN', 'name': u'Bravo Course 1', 'org': u'BravoOrg', 'number': u'B001' },
+    { 'id': u'course-v1:BravoOrg+B002+RUN', 'name': u'Bravo Course 2', 'org': u'BravoOrg', 'number': u'B002' },
+]
+
+def make_user(**kwargs):
+    '''
+
+    NOTE: Consider adding more fields. Refere to the serializer test for  the
+    GeneralUserDataSerializer
+    '''
+    return UserFactory(
+        id=kwargs['id'],
+        username=kwargs['username'],
+        profile__name=kwargs['fullname'],
+        profile__country=kwargs['country'],
+        is_active=kwargs['is_active'],
+    )
+
+def make_course(**kwargs):
+    return CourseOverviewFactory(
+        id=kwargs['id'], display_name=kwargs['name'], org=kwargs['org'], number=kwargs['number'])
+
+def make_course_enrollments(user, courses, **kwargs):
+    '''
+        creates course enrollments for every course in COURSE_DATA for the given user
+    '''
+    course_enrollments = []
+    for course in courses:
+        course_enrollments.append(
+            CourseEnrollmentFactory(
+                course_id=course.id,
+                user=user,
+                )
+            )
+
+@pytest.mark.django_db
+class TestGeneralUserViewSet(object):
+    '''Tests the UserIndexView view class
+    '''
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.users = [make_user(**data) for data in USER_DATA]
+        self.course_overviews = [make_course(**data) for data in COURSE_DATA]
+        self.course_enrollments = [make_course_enrollments(user, self.course_overviews) for user in self.users]
+        self.expected_result_keys = [
+            'id', 'username', 'fullname','country', 'is_active', 'gender',
+            'date_joined', 'year_of_birth', 'level_of_education', 'courses',
+            'language_proficiencies',
+        ]
+
+
+
+    def get_expected_results(self, **filter):
+        '''returns a list of dicts of the filtered user data
+
+        '''
+        return list(
+            get_user_model().objects.filter(**filter).annotate(
+                fullname=F('profile__name'), country=F('profile__country')
+                ).values(*self.expected_result_keys))
+
+    @pytest.mark.parametrize('endpoint, filter', [
+        ('api/users/general', {}),
+        ])
+    def test_get_general_user_list(self, endpoint, filter):
+        '''Tests retrieving a list of users with abbreviated details
+
+        The fields in each returned record are identified by
+            `figures.serializers.UserIndexSerializer`
+
+        '''
+        #expected_data = self.get_expected_results(**filter)
+        def get_course_rec(course_id, course_list):
+            recs = [rec for rec in course_list if rec['id'] == str(course_id)]
+            assert len(recs) == 1
+            return recs[0]
+
+        factory = APIRequestFactory()
+        request = factory.get(endpoint)
+        force_authenticate(request, user=self.users[0])
+        view = GeneralUserDataViewSet.as_view({'get': 'list'})
+        response = view(request)
+
+        # Later, we'll elaborate on the tests. For now, some basic checks
+        assert response.status_code == 200
+        assert len(response.data) == len(self.users)
+
+        User = get_user_model()
+        assert len(self.users) == User.objects.count()
+
+        for rec in response.data:
+            # fail if we cannot find the user in the models
+            user_model = User.objects.get(username=rec['username'])
+
+            assert set(rec.keys()) == set(self.expected_result_keys)
+
+            # check the courses
+            for course_enrollment in CourseEnrollment.objects.filter(user=user_model):
+                # Test that the course id exists in the data
+                course_rec = get_course_rec(course_enrollment.course_id, rec['courses'])


### PR DESCRIPTION

- returns all users with the courses for which each user is enrolled
- filterable on the course id via query parameter
- Added tests, not 100% field coverage, but have tests for the view and
serializer

Ref: API doc https://docs.google.com/document/d/16_4R0Q9YQ7IbofjWTXLsdMK_v-loBC7CUoARXw5LRqo/

Which is really just this:
```
General User Data

[
  {
    "username": "maxi",
    "country": "UY",
    "is_active": true,
    "year_of_birth": 1985,
    "level_of_education": "b",
    "gender": "m",
    "date_joined": "2018-05-06T14:01:58Z",
    "language_proficiencies": [],
    "courses": [
      {
        "course_name": "Something",
        "course_id": "A193+2016Q4+something",
      }
      ...
    ]
  },
  ...
]

```

The implementation differs slightly in the following ways:

* The date joined is a date and not a datetime. Let me know if the time of day is important and I'll change it to be datetime. I find that excessive datetimes muddy it up when a date is sufficient

* The actual data returned for each course item contains the keys 'id', 'display_name', 'org', 'number'
This is because I'm reusing the CourseIndexSerializer
* added 'fullname' to the data 

# Testing

Test coverage can use improvement. I have a baseline, but didn't want to sink time into either cobbling together some crappy code coverage and didn't want to invest time (at this time) into doing "proper and robust" coverage for how users and courses (CourseOverview) are associated through non-direct model relationships between User, CourseEnrollment, and CourseOverview)

# Issues

The 'number' for the course is not being returned. I need to investigate and fix that. This is also the value 'course_code' specified in the general course data endpoint
