### PR TITLE
Added general course data endpoint and supporting code

### DIFF
--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -3,14 +3,15 @@
 '''
 
 from rest_framework import serializers
+from rest_framework.fields import empty
 
 from openedx.core.djangoapps.content.course_overviews.models import (
     CourseOverview,
 )
 
-from student.models import CourseEnrollment
+from student.models import CourseAccessRole, CourseEnrollment
 
-from .models import CourseDailyMetrics, SiteDailyMetrics
+from figures.models import CourseDailyMetrics, SiteDailyMetrics
 
 ###
 ### Summary serializers for listing
@@ -82,3 +83,95 @@ class SiteDailyMetricsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = SiteDailyMetrics
+
+
+##
+## Serializers for serving the front end views
+##
+
+
+class CourseAccessRoleForGCDSerializer(serializers.ModelSerializer):
+    '''Serializer to return course staff data for GeneralCourseData
+    '''
+
+    user_id = serializers.IntegerField(source='user.id', read_only=True)
+    username = serializers.CharField(source='user.username', read_only=True)
+    fullname = serializers.CharField(source='user.profile.name', default=None,
+        read_only=True)
+    role = serializers.CharField(read_only=True)
+
+    class Meta:
+        model = CourseAccessRole
+        fields = ['user_id', 'username', 'fullname', 'role']
+
+
+class GeneralCourseDataSerializer(serializers.Serializer):
+    '''
+
+    Returns data in the format::
+
+        [
+            {
+                "course_id": "A101+SomethingSomething",
+                "course_name": "This is the course name",
+                "course_code": "A101",
+                "course_mode": "Something",
+                "org": "MyOrganization",
+                "start_date": "2017-07-15T16:59:51.740702Z", // can be empty
+                "end_date": "2017-07-15T16:59:51.740702Z", // can be empty
+                "self_paced": false,
+                "staff": [
+                    {
+                        "username": "matej",
+                        "fullname": "Matej Grozdanovic",
+                        "user_id": 123,
+                        "role": "instructor"
+                    },
+                    {
+                        "username": "bubba",
+                        "fullname": "Bubba Brown",
+                        "user_id": 42,
+                        "role": "staff"
+                    }
+                ],
+                "metrics": {
+                    "learners_enrolled": 123,
+                    "average_progress": 0.39, // percentage
+                    "average_completion_time": "some_time_in_standardised_format",
+                    "users_completed": 493, // total number of users that have completed the course since the course was created
+                }
+            },
+            ...
+        ]
+
+    '''
+    course_id = serializers.CharField(source='id', read_only=True)
+    course_name = serializers.CharField(source='display_name_with_default_escaped',
+        read_only=True)
+    course_code = serializers.CharField(source='display_number_with_default',
+        read_only=True)
+    org = serializers.CharField(source='display_org_with_default',
+        read_only=True)
+    start_date = serializers.DateTimeField(source='enrollment_start',
+        read_only=True, default=None)
+    end_date = serializers.DateTimeField(source='enrollment_end',
+        read_only=True, default=None)
+    self_paced = serializers.BooleanField(read_only=True)
+
+    staff = serializers.SerializerMethodField()
+
+    metrics = serializers.SerializerMethodField()
+
+    def get_staff(self, obj):
+        qs = CourseAccessRole.objects.filter(course_id=obj.id)
+        if qs:
+            return [CourseAccessRoleForGCDSerializer(data).data for data in qs]
+        else:
+            return []
+
+    def get_metrics(self, obj):
+        qs = CourseDailyMetrics.objects.filter(course_id=str(obj.id))
+        if qs:
+            return CourseDailyMetricsSerializer(qs.latest('date_for')).data
+        else:
+            return []

--- a/figures/urls.py
+++ b/figures/urls.py
@@ -27,6 +27,10 @@ router.register(
     views.CourseEnrollmentViewSet,
     base_name='course-enrollments')
 
+router.register(
+    r'courses/general',
+    views.GeneralCourseDataViewSet,
+    base_name='general-courses')
 
 urlpatterns = [
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,6 +12,7 @@ import datetime
 from django.contrib.auth import get_user_model
 #from django_countries.fields import CountryField
 import factory
+from factory import fuzzy
 from factory.django import DjangoModelFactory
 
 from openedx.core.djangoapps.content.course_overviews.models import (
@@ -20,7 +21,7 @@ from openedx.core.djangoapps.content.course_overviews.models import (
 
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
-from student.models import CourseEnrollment, UserProfile
+from student.models import CourseAccessRole, CourseEnrollment, UserProfile
 from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
 
 from figures.models import CourseDailyMetrics, SiteDailyMetrics
@@ -39,7 +40,11 @@ class CourseOverviewFactory(DjangoModelFactory):
     org = 'StarFleetAcademy'
     number = '2161'
     display_org_with_default = factory.LazyAttribute(lambda o: o.org)
-
+    enrollment_start = fuzzy.FuzzyDateTime(datetime.datetime(
+        2018,02,02, tzinfo=factory.compat.UTC))
+    self_paced = False
+    enrollment_end = fuzzy.FuzzyDateTime(datetime.datetime(
+        2018,05,05, tzinfo=factory.compat.UTC))
 
 class CourseTeamFactory(DjangoModelFactory):
     class Meta:
@@ -94,6 +99,17 @@ class CourseEnrollmentFactory(DjangoModelFactory):
     course_id = factory.Sequence(lambda n: COURSE_ID_STR_TEMPLATE.format(n))
     created = factory.Sequence(lambda n:
         datetime.datetime(2018, 1, 1) + datetime.timedelta(days=n))
+
+
+class CourseAccessRoleFactory(DjangoModelFactory):
+    class Meta:
+        model = CourseAccessRole
+    user = factory.SubFactory(
+        UserFactory,
+    )
+    course_id = factory.Sequence(lambda n: COURSE_ID_STR_TEMPLATE.format(n))
+    role = factory.Iterator(['instructor', 'staff'])
+
 
 
 ##

--- a/tests/mocks/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/tests/mocks/openedx/core/djangoapps/content/course_overviews/models.py
@@ -27,6 +27,9 @@ removing these mocks
 
 from django.db import models
 
+#from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+
 class CourseOverview(models.Model):
     '''
     Provides a mock model for the edx-platform 'CourseOverview' model
@@ -41,7 +44,8 @@ class CourseOverview(models.Model):
     '''
     # Faking id, picking arbitrary length
     # Actual field is of type opaque_keys.edx.keys.CourseKey
-    id = models.CharField(db_index=True, primary_key=True, max_length=255)
+    #id = models.CharField(db_index=True, primary_key=True, max_length=255)
+    id = CourseKeyField(db_index=True, primary_key=True, max_length=255)
     display_name = models.TextField(null=True)
     org = models.TextField(max_length=255, default='outdated_entry')
     # For the tests, the CourseOverviewFactory does a LazyAttribute on
@@ -49,6 +53,9 @@ class CourseOverview(models.Model):
     display_org_with_default = models.TextField()
     number = models.TextField()
 
+    enrollment_start = models.DateTimeField(null=True)
+    enrollment_end = models.DateTimeField(null=True)
+    self_paced = models.BooleanField(default=False)
     @property
     def display_name_with_default_escaped(self):
         return self.display_name

--- a/tests/mocks/student/models.py
+++ b/tests/mocks/student/models.py
@@ -38,3 +38,42 @@ class CourseEnrollment(models.Model):
     class Meta(object):
         unique_together = (('user', 'course_id'),)
         ordering = ('user', 'course_id')
+
+
+class CourseAccessRole(models.Model):
+    user = models.ForeignKey(User)
+    # blank org is for global group based roles such as course creator (may be deprecated)
+    org = models.CharField(max_length=64, db_index=True, blank=True)
+    # blank course_id implies org wide role
+    course_id = CourseKeyField(max_length=255, db_index=True, blank=True)
+    role = models.CharField(max_length=64, db_index=True)
+
+    class Meta(object):
+        unique_together = ('user', 'org', 'course_id', 'role')
+
+    @property
+    def _key(self):
+        """
+        convenience function to make eq overrides easier and clearer. arbitrary decision
+        that role is primary, followed by org, course, and then user
+        """
+        return (self.role, self.org, self.course_id, self.user_id)
+
+    def __eq__(self, other):
+        """
+        Overriding eq b/c the django impl relies on the primary key which requires fetch. sometimes we
+        just want to compare roles w/o doing another fetch.
+        """
+        return type(self) == type(other) and self._key == other._key  # pylint: disable=protected-access
+
+    def __hash__(self):
+        return hash(self._key)
+
+    def __lt__(self, other):
+        """
+        Lexigraphic sort
+        """
+        return self._key < other._key  # pylint: disable=protected-access
+
+    def __unicode__(self):
+        return "[CourseAccessRole] user: {}   role: {}   org: {}   course: {}".format(self.user.username, self.role, self.org, self.course_id)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -4,6 +4,7 @@
 
 from dateutil.parser import parse as dateutil_parse
 from decimal import Decimal
+from dateutil.parser import parse
 import pytest
 
 from django.db import models
@@ -14,16 +15,20 @@ from figures.models import CourseDailyMetrics, SiteDailyMetrics
 from figures.serializers import (
     CourseDailyMetricsSerializer,
     CourseEnrollmentSerializer,
+    GeneralCourseDataSerializer,
     SiteDailyMetricsSerializer,
     UserIndexSerializer,
 )
 
 from tests.factories import (
+    CourseAccessRoleFactory,
     CourseDailyMetricsFactory,
     CourseEnrollmentFactory,
+    CourseOverviewFactory,
     SiteDailyMetricsFactory,
     UserFactory,
     )
+
 
 @pytest.mark.django_db
 class TestUserIndexSerializer(object):
@@ -178,3 +183,65 @@ class TestSiteDailyMetricsSerializer(object):
 
         for field_name in (self.expected_results_keys - self.date_fields):
             assert data[field_name] == getattr(self.site_daily_metrics,field_name)
+
+
+@pytest.mark.django_db
+class TestGeneralCourseDataSerializer(object):
+    '''
+    TODO: Verify that learner roles are NOT in CourseAccessRole
+    If learner roles can be in this model, then we need to add test for verifying
+    that learner roles are not in the staff list of the general course data
+    '''
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        #self.course_id = 'course-v1:AlphaOrg+A001+RUN'
+
+        #self.enrollment_datetime = datetime.datetime(2018, 02, 02, tzinfo=pytz.UTC)
+        # self.course_overview_attributes = dict(
+        #     id=self.course_id,
+
+        # )
+        
+        #self.course_overview = CourseOverviewFactory(**self.course_overview_attributes)
+        self.course_overview = CourseOverviewFactory()
+        self.users = [ UserFactory(), UserFactory()]
+
+        self.course_access_roles = [
+            CourseAccessRoleFactory(
+                user=self.users[0],
+                course_id=self.course_overview.id,
+                role='staff'),
+            CourseAccessRoleFactory(
+                user=self.users[1],
+                course_id=self.course_overview.id,
+                role='administrator'),
+        ]
+
+        self.serializer = GeneralCourseDataSerializer(instance=self.course_overview)
+
+
+        self.expected_fields = [
+            'course_id', 'course_name', 'course_code','org', 'start_date',
+            'end_date', 'self_paced', 'staff', 'metrics',
+        ]
+
+    def test_has_fields(self):
+        '''Tests that the serialized general course  data has specific keys and values
+        '''
+        data = self.serializer.data
+        assert set(data.keys()) == set(self.expected_fields)
+
+        # This is to make sure that the serializer retrieves the correct nested
+        # model (UserProfile) data
+        assert data['course_id'] == str(self.course_overview.id)
+        assert data['course_name'] == self.course_overview.display_name
+        assert data['course_code'] == self.course_overview.number
+        assert data['org'] == self.course_overview.org
+        assert parse(data['start_date']) == self.course_overview.enrollment_start
+        assert parse(data['end_date']) == self.course_overview.enrollment_end
+        assert data['self_paced'] == self.course_overview.self_paced
+
+        #assert data[''] == self.course_overview.
+        
+
+        #assert data['date_joined'] == str(self.a_datetime.date())

--- a/tests/views/test_general_course_data_view.py
+++ b/tests/views/test_general_course_data_view.py
@@ -1,0 +1,127 @@
+
+import pytest
+
+from django.contrib.auth import get_user_model
+from django.db.models import F
+
+from rest_framework.test import (
+    APIRequestFactory,
+    #RequestsClient, Not supported in older  rest_framework versions
+    force_authenticate,
+    )
+
+from openedx.core.djangoapps.content.course_overviews.models import (
+    CourseOverview,
+)
+from student.models import CourseEnrollment
+
+from figures.helpers import as_course_key
+from figures.views import (
+    GeneralCourseDataViewSet,
+    )
+
+from tests.factories import (
+    CourseDailyMetricsFactory,
+    CourseEnrollmentFactory,
+    CourseOverviewFactory,
+    UserFactory,
+    )
+
+COURSE_ID_STR_TEMPLATE = 'course-v1:StarFleetAcademy+SFA{}+2161'
+
+USER_DATA = [
+    {'id': 1, 'username': u'alpha', 'fullname': u'Alpha One',
+     'is_active': True, 'country': 'CA'},
+    {'id': 2, 'username': u'alpha02', 'fullname': u'Alpha Two', 'is_active': False, 'country': 'UK'},
+    {'id': 3, 'username': u'bravo', 'fullname': u'Bravo One', 'is_active': True, 'country': 'US'},
+    {'id': 4, 'username': u'bravo02', 'fullname': u'Bravo Two', 'is_active': True, 'country': 'UY'},
+]
+
+COURSE_DATA = [
+    { 'id': u'course-v1:AlphaOrg+A001+RUN', 'name': u'Alpha Course 1', 'org': u'AlphaOrg', 'number': u'A001' },
+    { 'id': u'course-v1:AlphaOrg+A002+RUN', 'name': u'Alpha Course 2', 'org': u'AlphaOrg', 'number': u'A002' },
+    { 'id': u'course-v1:BravoOrg+A001+RUN', 'name': u'Bravo Course 1', 'org': u'BravoOrg', 'number': u'B001' },
+    { 'id': u'course-v1:BravoOrg+B002+RUN', 'name': u'Bravo Course 2', 'org': u'BravoOrg', 'number': u'B002' },
+]
+
+def make_user(**kwargs):
+    '''
+
+    NOTE: Consider adding more fields. Refere to the serializer test for  the
+    GeneralUserDataSerializer
+    '''
+    return UserFactory(
+        id=kwargs['id'],
+        username=kwargs['username'],
+        profile__name=kwargs['fullname'],
+        profile__country=kwargs['country'],
+        is_active=kwargs['is_active'],
+    )
+
+def make_course(**kwargs):
+    return CourseOverviewFactory(
+        id=kwargs['id'], display_name=kwargs['name'], org=kwargs['org'], number=kwargs['number'])
+
+def make_course_enrollments(user, courses, **kwargs):
+    '''
+        creates course enrollments for every course in COURSE_DATA for the given user
+    '''
+    course_enrollments = []
+    for course in courses:
+        course_enrollments.append(
+            CourseEnrollmentFactory(
+                course_id=course.id,
+                user=user,
+                )
+            )
+
+@pytest.mark.django_db
+class TestGeneralCourseDataViewSet(object):
+    '''Tests the UserIndexView view class
+    '''
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.users = [make_user(**data) for data in USER_DATA]
+        self.course_overviews = [make_course(**data) for data in COURSE_DATA]
+        #self.course_enrollments = [make_course_enrollments(user, self.course_overviews) for user in self.users]
+        #self.course_daily_metrics = [make_course_daily_metrics()]
+        self.expected_result_keys = [
+            'course_id', 'course_name', 'course_code','org', 'start_date',
+            'end_date', 'self_paced', 'staff', 'metrics',
+        ]
+
+    @pytest.mark.parametrize('endpoint, filter', [
+        ('api/courses/general', {}),
+        ])
+    def test_get_list(self, endpoint, filter):
+        '''Tests retrieving a list of users with abbreviated details
+
+        The fields in each returned record are identified by
+            `figures.serializers.UserIndexSerializer`
+        '''
+
+        factory = APIRequestFactory()
+        request = factory.get(endpoint)
+        force_authenticate(request, user=self.users[0])
+        view = GeneralCourseDataViewSet.as_view({'get': 'list'})
+        response = view(request)
+
+        # Later, we'll elaborate on the tests. For now, some basic checks
+        assert response.status_code == 200
+        assert len(response.data) == len(self.course_overviews)
+
+        for rec in response.data:
+
+            course_overview = CourseOverview.objects.get(id=as_course_key(rec['course_id']))
+
+            # Test top level vars
+            assert rec['course_name'] == course_overview.display_name
+
+            assert rec['course_id'] == str(course_overview.id)
+            # TODO: add asserts for more fields
+            # TODO as testing improvement future work: validating metrics and staff
+            # We're starting to need more complex data set-up, so deferring to
+            # implement a 
+
+


### PR DESCRIPTION
This is to support providing course data efficiently to the UI for the
course list (currently in the Site metrics page) and for general
information for individual course pages

- General course data returns information from the CourseOverview,
CourseAccessRole, User, UserProfile, and CourseDailyMetrics models
- Both course list and single course data provided
- Added serialier for general course data
- Added specialized serializer for CourseAccessRole for the general
course data
- Added view and serializer tests for the general course data
- Added CourseAccessRole to the mocks