### PR TITLE
Figures multisite support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ node_js:
 
 # command to install dependencies
 install:
-  - pip install -r devsite/requirements.txt
-  - pip install pytest-cov flake8
+  - pip install -r devsite/requirements/base.txt
+  - pip install pytest-cov flake8 tox
   - cd frontend && npm install && cd ..
 
 # command to run tests
@@ -17,4 +17,7 @@ script:
   - flake8 figures
   - py.test --cov=./
   - bash <(curl -s https://codecov.io/bash)
-  
+  - tox
+
+env:
+  - TOXENV=py27-openedx_ginkgo

--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -22,6 +22,9 @@ USE_TZ = True
 TIME_ZONE = 'UTC'
 ALLOWED_HOSTS = []
 
+# Set the default Site (django.contrib.sites.models.Site)
+SITE_ID = 1
+
 # Adds the mock edx-platform modules to the Python module search path
 sys.path.append(
     os.path.normpath(os.path.join(PROJECT_ROOT_DIR, 'tests/mocks'))
@@ -33,6 +36,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'django.contrib.sites',
     'django.contrib.staticfiles',
     'django_extensions',
     'rest_framework',

--- a/devsite/devsite/test_settings.py
+++ b/devsite/devsite/test_settings.py
@@ -15,6 +15,10 @@ def root(*args):
     """
     return join(abspath(dirname(__file__)), *args)
 
+
+# Set the default Site (django.contrib.sites.models.Site)
+SITE_ID = 1
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -30,6 +34,7 @@ DATABASES = {
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.sites',
     'rest_framework',
     'django_countries',
     'django_filters',
@@ -86,4 +91,3 @@ if 'figures' in INSTALLED_APPS:
         WEBPACK_LOADER,
         CELERYBEAT_SCHEDULE,
         ENV_TOKENS.get('FIGURES', {}))
-

--- a/devsite/devsite/test_settings.py
+++ b/devsite/devsite/test_settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.content.course_overviews',
     'student',
     'certificates',
+    'organizations',
 )
 
 LOCALE_PATHS = [

--- a/devsite/requirements.txt
+++ b/devsite/requirements.txt
@@ -45,6 +45,14 @@ recommonmark==0.4.0
 edx-opaque-keys==0.4
 #edx-drf-extensions==1.2.2
 
+# Hopefully a very temporary fix
+# * Organization/site mapping requires Appsembler's fork
+# edx-organizations==0.4.1
+git+https://github.com/appsembler/edx-organizations.git@0.4.1-appsembler10
+
+# #egg=edx-organizations==0.4.1-appsembler
+
+
 ##
 ## Pytest dependencies
 ##

--- a/devsite/requirements/appsembler_multisite.txt
+++ b/devsite/requirements/appsembler_multisite.txt
@@ -1,0 +1,65 @@
+# Requirements needed by the devsite app server and test suite
+# For initial development, we're just importing all the packages needed
+# for both running the devsite server and for the pytest dependencies
+#
+
+# Versions should match those used in Open edX Ginkgo
+
+##
+## General Python package dependencies
+###
+
+celery==3.1.18
+
+python-dateutil==2.1
+path.py==8.2.1
+
+# Yes, this is old but is the one specified by Ginkgo edx-platform
+pytz==2016.7
+
+##
+## Django package dependencies
+##
+
+Django==1.8.12
+django-extensions==1.5.9
+djangorestframework==3.2.3
+django-countries==4.0
+django-filter==0.11.0
+django-webpack-loader==0.5.0
+django-model-utils==2.3.1
+
+jsonfield==1.0.3  # Version used in Ginkgo. Hawthorn uses version 2.0.2
+
+##
+## Documentation (Sphinx) dependencies
+##
+
+Sphinx==1.8.1
+recommonmark==0.4.0
+
+##
+## Open edX package dependencies
+##
+
+edx-opaque-keys==0.4
+#edx-drf-extensions==1.2.2
+
+# edx-organizations==0.4.1
+# * Organization/site mapping requires Appsembler's fork
+git+https://github.com/appsembler/edx-organizations.git@0.4.1-appsembler10
+
+
+##
+## Pytest dependencies
+##
+
+coverage==4.5.1
+factory-boy==2.5.1
+pylint==1.8.2
+pylint-django==0.9.1
+pytest==3.1.3
+pytest-django==3.1.2
+pytest-mock==1.7.1
+pytest-pythonpath==0.7.2
+pytest-cov==2.6.0

--- a/devsite/requirements/base.txt
+++ b/devsite/requirements/base.txt
@@ -44,14 +44,7 @@ recommonmark==0.4.0
 
 edx-opaque-keys==0.4
 #edx-drf-extensions==1.2.2
-
-# Hopefully a very temporary fix
-# * Organization/site mapping requires Appsembler's fork
-# edx-organizations==0.4.1
-git+https://github.com/appsembler/edx-organizations.git@0.4.1-appsembler10
-
-# #egg=edx-organizations==0.4.1-appsembler
-
+edx-organizations==0.4.1
 
 ##
 ## Pytest dependencies

--- a/figures/metrics.py
+++ b/figures/metrics.py
@@ -31,7 +31,6 @@ from django.db.models import Avg, Max
 from certificates.models import GeneratedCertificate
 from courseware.courses import get_course_by_id
 from courseware.models import StudentModule
-from student.models import CourseEnrollment
 
 from figures.compat import CourseGradeFactory, chapter_grade_values
 from figures.helpers import (

--- a/figures/migrations/0005_add_site_to_models.py
+++ b/figures/migrations/0005_add_site_to_models.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sites', '0001_initial'),
+        ('figures', '0004_learner_course_grade_metrics'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='sitedailymetrics',
+            options={'ordering': ['-date_for', 'site']},
+        ),
+        migrations.AddField(
+            model_name='coursedailymetrics',
+            name='site',
+            field=models.ForeignKey(default=1, to='sites.Site'),
+        ),
+        migrations.AddField(
+            model_name='learnercoursegrademetrics',
+            name='site',
+            field=models.ForeignKey(default=1, to='sites.Site'),
+        ),
+        migrations.AddField(
+            model_name='pipelineerror',
+            name='site',
+            field=models.ForeignKey(blank=True, to='sites.Site', null=True),
+        ),
+        migrations.AddField(
+            model_name='sitedailymetrics',
+            name='site',
+            field=models.ForeignKey(default=1, to='sites.Site'),
+        ),
+        migrations.AlterField(
+            model_name='sitedailymetrics',
+            name='date_for',
+            field=models.DateField(),
+        ),
+    ]

--- a/figures/migrations/0006_remove_default_site_from_models.py
+++ b/figures/migrations/0006_remove_default_site_from_models.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('figures', '0005_add_site_to_models'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='coursedailymetrics',
+            name='site',
+            field=models.ForeignKey(to='sites.Site'),
+        ),
+        migrations.AlterField(
+            model_name='learnercoursegrademetrics',
+            name='site',
+            field=models.ForeignKey(to='sites.Site'),
+        ),
+        migrations.AlterField(
+            model_name='sitedailymetrics',
+            name='site',
+            field=models.ForeignKey(to='sites.Site'),
+        ),
+    ]

--- a/figures/models.py
+++ b/figures/models.py
@@ -21,6 +21,7 @@ class CourseDailyMetrics(TimeStampedModel):
     adding a SiteDailyMetrics foreign key. This is subject to change as the code
     evolves.
     """
+    site = models.ForeignKey(Site)
     date_for = models.DateField()
 
     # Leaving as a simple string for initial development
@@ -28,7 +29,6 @@ class CourseDailyMetrics(TimeStampedModel):
     # the CourseOverview model or have the course_id be a
     # CourseKeyField
     course_id = models.CharField(max_length=255)
-    site = models.ForeignKey(Site, default=settings.SITE_ID)
     enrollment_count = models.IntegerField()
     active_learners_today = models.IntegerField()
     # Do we want cumulative average progress for the month?
@@ -54,9 +54,9 @@ class SiteDailyMetrics(TimeStampedModel):
     Stores metrics for a given site and day
     """
 
+    site = models.ForeignKey(Site)
     # Date for which this record's data are collected
     date_for = models.DateField()
-    site = models.ForeignKey(Site, default=settings.SITE_ID)
     cumulative_active_user_count = models.IntegerField(blank=True, null=True)
     todays_active_user_count = models.IntegerField(blank=True, null=True)
     total_user_count = models.IntegerField()
@@ -116,11 +116,11 @@ class LearnerCourseGradeMetrics(TimeStampedModel):
     actually needed and edx-platform uses FloatField in its grades models
 
     """
+    site = models.ForeignKey(Site)
     date_for = models.DateField()
     # TODO: We should require the user
     user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
     course_id = models.CharField(max_length=255, blank=True)
-    site = models.ForeignKey(Site, default=settings.SITE_ID)
     points_possible = models.FloatField()
     points_earned = models.FloatField()
     sections_worked = models.IntegerField()

--- a/figures/permissions.py
+++ b/figures/permissions.py
@@ -10,13 +10,46 @@ import organizations
 import figures.settings
 
 
-def is_site_admin_user(request):
+class MultipleOrgsPerUserNotSupported(Exception):
+    pass
 
-    if not figures.settings.is_multisite():
-        has_permission = IsStaffUser().has_permission(request, None)
-    else:
+
+def is_site_admin_user(request):
+    """
+    Determines if the requesting user has access to site admin data
+
+    * If Figures is running in standalone mode, then the user needs to be staff
+      or superuser.
+    * If figures is running in multisite mode, then the user needs to belong to
+      the site through the site's organization and have admin permission for
+      that organization
+
+    ## Multisite implementation
+
+    This initial multisite implementation assumes a user belongs to only one
+    organization in a site. This is represented in the UserOrganizationMapping
+    model in Appsembler's fork of edx-organizations. This model currently does
+    not enforce user-org uniquness. Therefore, multiple records returned is an
+    error and the behavior is undefined. Multiple user organiazation mappings
+    found will raise an exception to prevent returning invalid authorization.
+
+    To support multiple user organization mappings per site, we need to
+    determine the authorization criteria in that environment.
+
+    Note: Depending on community participation, we may make this a pluggable
+    feature but there are other considerations such as future built-in support
+    for site and organization access control in the futire.
+
+
+    ## What this function does
+
+    1. Get the current site (matching the request)
+    2. Get the orgs for the site. We assume only one org
+    3. Get the user org mappings for the orgs and user in the request
+    4. Check the uom record if user is admin and active
+    """
+    if figures.settings.is_multisite():
         current_site = django.contrib.sites.shortcuts.get_current_site(request)
-        # get orgs for the site
         orgs = organizations.models.Organization.objects.filter(sites__in=[current_site])
         # Should just be mappings for organizations in this site
         # If just one organization in a site, then the queryset returned
@@ -24,26 +57,28 @@ def is_site_admin_user(request):
         uom_qs = organizations.models.UserOrganizationMapping.objects.filter(
             organization__in=orgs,
             user=request.user)
+
+        # This is here to Fail because multiple orgs per site is unsupported
+        if uom_qs.count() > 1:
+            raise MultipleOrgsPerUserNotSupported(
+                'Only one org per user per site is allowed. found {}'.format(
+                    uom_qs.count())
+                )
         # Since Tahoe does just one org, we're going to cheat and just look
         # for the first element
-        if uom_qs:
+        if uom_qs and request.user.is_active:
             has_permission = uom_qs[0].is_amc_admin and uom_qs[0].is_active
         else:
             has_permission = False
+    else:
+        has_permission = is_active_staff_or_superuser(request)
+
     return has_permission
 
 
 def is_active_staff_or_superuser(request):
     return request.user and request.user.is_active and (
            request.user.is_staff or request.user.is_superuser)
-
-
-class IsStaffUser(BasePermission):
-    """
-    Allow access to only active staff users or superusers
-    """
-    def has_permission(self, request, view):
-        return is_active_staff_or_superuser(request)
 
 
 class IsSiteAdminUser(BasePermission):

--- a/figures/permissions.py
+++ b/figures/permissions.py
@@ -3,11 +3,49 @@
 '''
 from rest_framework.permissions import BasePermission
 
+import django.contrib.sites.shortcuts
+
+import organizations
+
+import figures.settings
+
+
+def is_site_admin_user(request):
+
+    if not figures.settings.is_multisite():
+        has_permission = IsStaffUser().has_permission(request, None)
+    else:
+        current_site = django.contrib.sites.shortcuts.get_current_site(request)
+        # get orgs for the site
+        orgs = organizations.models.Organization.objects.filter(sites__in=[current_site])
+        # Should just be mappings for organizations in this site
+        # If just one organization in a site, then the queryset returned
+        # should contain just one element
+        uom_qs = organizations.models.UserOrganizationMapping.objects.filter(
+            organization__in=orgs,
+            user=request.user)
+        # Since Tahoe does just one org, we're going to cheat and just look
+        # for the first element
+        if uom_qs:
+            has_permission = uom_qs[0].is_amc_admin and uom_qs[0].is_active
+        else:
+            has_permission = False
+    return has_permission
+
 
 class IsStaffUser(BasePermission):
     """
-    Allow access to only staff users
+    Allow access to only staff users or superusers
     """
     def has_permission(self, request, view):
         return request.user and request.user.is_active and (
             request.user.is_staff or request.user.is_superuser)
+
+
+class IsSiteAdminUser(BasePermission):
+    """
+    Allow access to only site admins if in multisite mode or staff or superuser
+    if in standalone mode
+    """
+    def has_permission(self, request, view):
+        return is_site_admin_user(request)

--- a/figures/permissions.py
+++ b/figures/permissions.py
@@ -33,13 +33,17 @@ def is_site_admin_user(request):
     return has_permission
 
 
+def is_active_staff_or_superuser(request):
+    return request.user and request.user.is_active and (
+           request.user.is_staff or request.user.is_superuser)
+
+
 class IsStaffUser(BasePermission):
     """
-    Allow access to only staff users or superusers
+    Allow access to only active staff users or superusers
     """
     def has_permission(self, request, view):
-        return request.user and request.user.is_active and (
-            request.user.is_staff or request.user.is_superuser)
+        return is_active_staff_or_superuser(request)
 
 
 class IsSiteAdminUser(BasePermission):

--- a/figures/permissions.py
+++ b/figures/permissions.py
@@ -14,6 +14,14 @@ class MultipleOrgsPerUserNotSupported(Exception):
     pass
 
 
+def is_active_staff_or_superuser(request):
+    """
+    Standalone mode authorization check
+    """
+    return request.user and request.user.is_active and (
+           request.user.is_staff or request.user.is_superuser)
+
+
 def is_site_admin_user(request):
     """
     Determines if the requesting user has access to site admin data
@@ -74,11 +82,6 @@ def is_site_admin_user(request):
         has_permission = is_active_staff_or_superuser(request)
 
     return has_permission
-
-
-def is_active_staff_or_superuser(request):
-    return request.user and request.user.is_active and (
-           request.user.is_staff or request.user.is_superuser)
 
 
 class IsSiteAdminUser(BasePermission):

--- a/figures/permissions.py
+++ b/figures/permissions.py
@@ -88,6 +88,8 @@ class IsSiteAdminUser(BasePermission):
     """
     Allow access to only site admins if in multisite mode or staff or superuser
     if in standalone mode
+
+    Would `has_object_permission` help simplify filtering by site?
     """
     def has_permission(self, request, view):
         return is_site_admin_user(request)

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -24,6 +24,7 @@ from figures.models import CourseDailyMetrics, PipelineError
 from figures.pipeline.logger import log_error
 import figures.pipeline.loaders
 from figures.serializers import CourseIndexSerializer
+import figures.sites
 
 # TODO: Move extractors to figures.pipeline.extract module
 
@@ -263,6 +264,7 @@ class CourseDailyMetricsLoader(object):
 
     def __init__(self, course_id):
         self.course_id = course_id
+        # TODO: Consider adding extractor as optional param
         self.extractor = CourseDailyMetricsExtractor()
 
     def get_data(self, date_for):
@@ -300,6 +302,7 @@ class CourseDailyMetricsLoader(object):
         data = self.get_data(date_for=date_for)
         cdm, created = CourseDailyMetrics.objects.update_or_create(
             course_id=self.course_id,
+            site=figures.sites.get_site_for_course(self.course_id),
             date_for=date_for,
             defaults=dict(
                 enrollment_count=data['enrollment_count'],

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -82,11 +82,11 @@ def get_average_progress(course_id, date_for, course_enrollments):
     """Collects and aggregates raw course grades data
     """
     progress = []
-
     for ce in course_enrollments:
         try:
             course_progress = figures.metrics.LearnerCourseGrades.course_progress(ce)
             figures.pipeline.loaders.save_learner_course_grades(
+                site=figures.sites.get_site_for_course(course_id),
                 date_for=date_for,
                 course_enrollment=ce,
                 course_progress_details=course_progress['course_progress_details'])

--- a/figures/pipeline/loaders.py
+++ b/figures/pipeline/loaders.py
@@ -3,7 +3,6 @@
 """
 
 from figures.models import LearnerCourseGradeMetrics
-import figures.sites
 
 
 def save_learner_course_grades(site, date_for, course_enrollment, course_progress_details):

--- a/figures/pipeline/loaders.py
+++ b/figures/pipeline/loaders.py
@@ -3,9 +3,10 @@
 """
 
 from figures.models import LearnerCourseGradeMetrics
+import figures.sites
 
 
-def save_learner_course_grades(date_for, course_enrollment, course_progress_details):
+def save_learner_course_grades(site, date_for, course_enrollment, course_progress_details):
     """
 
     ``course_progress_details`` data are the ``course_progress_details`` from the
@@ -20,6 +21,7 @@ def save_learner_course_grades(date_for, course_enrollment, course_progress_deta
         sections_possible=course_progress_details['count']
         )
     obj, created = LearnerCourseGradeMetrics.objects.update_or_create(
+        site=site,
         user=course_enrollment.user,
         course_id=str(course_enrollment.course_id),
         date_for=date_for,

--- a/figures/pipeline/logger.py
+++ b/figures/pipeline/logger.py
@@ -32,4 +32,6 @@ def log_error(error_data, error_type=None, **kwargs):
             data.update(user=kwargs['user'])
         if 'course_id' in kwargs:
             data.update(course_id=str(kwargs['course_id']))
+        if 'site' in kwargs:
+            data.update(site=kwargs['site'])
         PipelineError.objects.create(**data)

--- a/figures/pipeline/site_daily_metrics.py
+++ b/figures/pipeline/site_daily_metrics.py
@@ -9,12 +9,7 @@ course metrics. These data are extracted directly from edx-platform models
 import datetime
 
 from django.utils.timezone import utc
-from django.contrib.auth import get_user_model
 from django.db.models import Sum
-
-from openedx.core.djangoapps.content.course_overviews.models import (
-    CourseOverview,
-)
 
 from figures.helpers import as_course_key, as_datetime, next_day, prev_day
 from figures.models import CourseDailyMetrics, SiteDailyMetrics

--- a/figures/pipeline/site_daily_metrics.py
+++ b/figures/pipeline/site_daily_metrics.py
@@ -136,9 +136,15 @@ class SiteDailyMetricsLoader(object):
     def __init__(self, extractor=None):
         self.extractor = extractor or SiteDailyMetricsExtractor()
 
-    def load(self, date_for=None, force_update=False, **kwargs):
+    def load(self, site, date_for=None, force_update=False, **kwargs):
         '''
-        TODO: Add filtering for
+        Architectural note:
+        Initially, we're going to be explicit, requiring callers to specify the
+        site model instance to be associated with the site specific metrics
+        model(s) we are populating
+
+        TODOs:
+        Add filtering for
         * Multi-tenancy
         * Course acess groups
         '''
@@ -151,7 +157,7 @@ class SiteDailyMetricsLoader(object):
         # then skip getting data
         if not force_update:
             try:
-                sdm = SiteDailyMetrics.objects.get(date_for=date_for)
+                sdm = SiteDailyMetrics.objects.get(date_for=date_for, site=site)
                 return (sdm, False,)
 
             except SiteDailyMetrics.DoesNotExist:
@@ -161,6 +167,7 @@ class SiteDailyMetricsLoader(object):
         data = self.extractor.extract(date_for=date_for)
         site_metrics, created = SiteDailyMetrics.objects.update_or_create(
             date_for=date_for,
+            site=site,
             defaults=dict(
                 cumulative_active_user_count=data['cumulative_active_user_count'],
                 todays_active_user_count=data['todays_active_user_count'],

--- a/figures/pipeline/site_daily_metrics.py
+++ b/figures/pipeline/site_daily_metrics.py
@@ -18,6 +18,7 @@ from openedx.core.djangoapps.content.course_overviews.models import (
 
 from figures.helpers import as_course_key, as_datetime, next_day, prev_day
 from figures.models import CourseDailyMetrics, SiteDailyMetrics
+import figures.sites
 
 
 #
@@ -25,7 +26,7 @@ from figures.models import CourseDailyMetrics, SiteDailyMetrics
 #
 
 
-def missing_course_daily_metrics(date_for):
+def missing_course_daily_metrics(site, date_for):
     '''
     Return a list of course ids for any courses missing from the set of
     CourseDailyMetrics for the given date (and site after we implement multi-
@@ -37,10 +38,11 @@ def missing_course_daily_metrics(date_for):
     '''
     cdm_course_keys = [
         as_course_key(cdm.course_id) for cdm in
-        CourseDailyMetrics.objects.filter(date_for=date_for)
+        CourseDailyMetrics.objects.filter(site=site, date_for=date_for)
     ]
 
-    course_overviews = CourseOverview.objects.filter(
+    site_course_overviews = figures.sites.get_courses_for_site(site)
+    course_overviews = site_course_overviews.filter(
         created__lt=next_day(date_for)).exclude(id__in=cdm_course_keys)
 
     return set(course_overviews.values_list('id', flat=True))
@@ -50,15 +52,15 @@ def missing_course_daily_metrics(date_for):
 # Standalone methods to extract data/aggregate data for use in SiteDailyMetrics
 #
 
-def get_active_user_count_for_date(date_for, course_daily_metrics=None):
+def get_active_user_count_for_date(site, date_for, course_daily_metrics=None):
     '''
 
     Do we have course daily metrics for the date_for?
     If so, we can use the data there,
     else, we need to calculate it or raise that we don't have data we need
     '''
-    aggregates = CourseDailyMetrics.objects.filter(date_for=date_for).aggregate(
-        Sum('active_learners_today'))
+    aggregates = CourseDailyMetrics.objects.filter(
+        site=site, date_for=date_for).aggregate(Sum('active_learners_today'))
     if aggregates and 'active_learners_today__sum' in aggregates:
         todays_active_user_count = aggregates['active_learners_today__sum'] or 0
     else:
@@ -66,7 +68,7 @@ def get_active_user_count_for_date(date_for, course_daily_metrics=None):
     return todays_active_user_count
 
 
-def get_previous_cumulative_active_user_count(date_for):
+def get_previous_cumulative_active_user_count(site, date_for):
     ''' Returns the cumulative site-wide active user count for the previous day
 
     This is a simple helper function that returns the cumulative active user
@@ -75,16 +77,18 @@ def get_previous_cumulative_active_user_count(date_for):
     '''
     try:
         return SiteDailyMetrics.objects.get(
+            site=site,
             date_for=prev_day(date_for)).cumulative_active_user_count or 0
     except SiteDailyMetrics.DoesNotExist:
         return 0
 
 
-def get_total_enrollment_count(date_for, course_ids=None):
+def get_total_enrollment_count(site, date_for, course_ids=None):
     '''Returns the total enrollments across all courses for the site
     It does not return unique learners
     '''
-    aggregates = CourseDailyMetrics.objects.filter(date_for=date_for).aggregate(
+    aggregates = CourseDailyMetrics.objects.filter(
+        site=site, date_for=date_for).aggregate(
         Sum('enrollment_count'))
     if aggregates and 'enrollment_count__sum' in aggregates:
         enrollment_count = aggregates['enrollment_count__sum'] or 0
@@ -102,7 +106,7 @@ class SiteDailyMetricsExtractor(object):
     def __init__(self):
         pass
 
-    def extract(self, date_for=None, **kwargs):
+    def extract(self, site, date_for=None, **kwargs):
         '''
         We get the count from the User model since there can be registered users
         who have not enrolled.
@@ -116,18 +120,20 @@ class SiteDailyMetricsExtractor(object):
 
         data = dict()
 
-        user_count = get_user_model().objects.filter(
+        site_users = figures.sites.get_users_for_site(site)
+        user_count = site_users.filter(
             date_joined__lt=as_datetime(next_day(date_for))).count()
-        course_count = CourseOverview.objects.filter(
+        site_courses = figures.sites.get_courses_for_site(site)
+        course_count = site_courses.filter(
             created__lt=as_datetime(next_day(date_for))).count()
 
-        todays_active_user_count = get_active_user_count_for_date(date_for)
+        todays_active_user_count = get_active_user_count_for_date(site, date_for)
         data['todays_active_user_count'] = todays_active_user_count
         data['cumulative_active_user_count'] = get_previous_cumulative_active_user_count(
-            date_for) + todays_active_user_count
+            site, date_for) + todays_active_user_count
         data['total_user_count'] = user_count
         data['course_count'] = course_count
-        data['total_enrollment_count'] = get_total_enrollment_count(date_for)
+        data['total_enrollment_count'] = get_total_enrollment_count(site, date_for)
         return data
 
 
@@ -157,14 +163,14 @@ class SiteDailyMetricsLoader(object):
         # then skip getting data
         if not force_update:
             try:
-                sdm = SiteDailyMetrics.objects.get(date_for=date_for, site=site)
+                sdm = SiteDailyMetrics.objects.get(site=site, date_for=date_for)
                 return (sdm, False,)
 
             except SiteDailyMetrics.DoesNotExist:
                 # proceed normally
                 pass
 
-        data = self.extractor.extract(date_for=date_for)
+        data = self.extractor.extract(site=site, date_for=date_for)
         site_metrics, created = SiteDailyMetrics.objects.update_or_create(
             date_for=date_for,
             site=site,

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -160,18 +160,10 @@ class CourseDailyMetricsSerializer(serializers.ModelSerializer):
 class SiteDailyMetricsSerializer(serializers.ModelSerializer):
     """Proviedes summary data about the LMS site
     """
-    # site_name
-
-    # site_id = serializers.IntegerField(source='site.id')
     site = SiteSerializer()
+
     class Meta:
         model = SiteDailyMetrics
-        # fields = [
-        #     'id', 'site_id', 'date_for', 'cumulative_active_user_count',
-        #     'todays_active_user_count',
-        #     'total_user_count', 'course_count', 'total_enrollment_count',
-        #     'created', 'modified'
-        # ]
 
 
 #

--- a/figures/settings.py
+++ b/figures/settings.py
@@ -25,7 +25,7 @@ def is_multisite():
     """
     Override by setting ``IS_MULTISITE`` to true in the Figures env settings
     """
-    return bool(env_tokens.get('IS_MULTISITE',
+    return bool(env_tokens.get('IS_FIGURES_MULTISITE',
                                DEFAULT_IS_MULTISITE))
 
 

--- a/figures/settings.py
+++ b/figures/settings.py
@@ -15,9 +15,18 @@ DEFAULT_PAGINATION_LIMIT = 20
 
 DAILY_METRICS_CELERY_TASK_LABEL = 'figures-populate-daily-metrics'
 
+DEFAULT_IS_MULTISITE = False
 DEFAULT_LOG_PIPELINE_ERRORS_TO_DB = True
 
 env_tokens = {}
+
+
+def is_multisite():
+    """
+    Override by setting ``IS_MULTISITE`` to true in the Figures env settings
+    """
+    return bool(env_tokens.get('IS_MULTISITE',
+                               DEFAULT_IS_MULTISITE))
 
 
 def log_pipeline_errors_to_db():

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -65,7 +65,10 @@ def get_site_for_course(course_id):
 
 
 def get_organizations_for_site(site):
-    orgs = organizations.models.Organization.objects.filter(sites__in=[site])
+    """
+    TODO: Refactor the functions in this module that make this call
+    """
+    return organizations.models.Organization.objects.filter(sites__in=[site])
 
 
 def get_course_keys_for_site(site):

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -3,7 +3,7 @@
 figuers.sites provides a single point to retrieve site specific data
 
 In general, the rest of Figures should call this module to retrieve all site
-specific data in edx-platform, such as users, course overviews, and 
+specific data in edx-platform, such as users, course overviews, and
 course enrollments as examples
 
 TODO:
@@ -118,9 +118,3 @@ def get_users_for_site(site):
 def get_course_enrollments_for_site(site):
     course_keys = get_course_keys_for_site(site)
     return CourseEnrollment.objects.filter(course_id__in=course_keys)
-
-
-# MultipleObjectsReturned: get() returned more than one UserOrganizationMapping -- it returned 5!
-
-#  File "/edx/src/figures/figures/orgs.py", line 40, in get_users_for_site
-#    organization__in=orgs)

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -1,5 +1,11 @@
 """
 
+figuers.sites provides a single point to retrieve site specific data
+
+In general, the rest of Figures should call this module to retrieve all site
+specific data in edx-platform, such as users, course overviews, and 
+course enrollments as examples
+
 TODO:
 Document how organization site mapping works
 """
@@ -56,6 +62,10 @@ def get_site_for_course(course_id):
         # Operating in single site / standalone mode, return the default site
         site = Site.objects.get(id=settings.SITE_ID)
     return site
+
+
+def get_organizations_for_site(site):
+    orgs = organizations.models.Organization.objects.filter(sites__in=[site])
 
 
 def get_course_keys_for_site(site):

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -1,0 +1,113 @@
+"""
+
+TODO:
+Document how organization site mapping works
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from django.conf import settings
+
+# TODO: Add exception handling
+import organizations
+
+from openedx.core.djangoapps.content.course_overviews.models import (
+    CourseOverview,
+)
+from student.models import CourseEnrollment
+
+from figures.helpers import as_course_key
+import figures.settings
+
+
+def get_site_for_course(course_id):
+    """
+    Given a course, return the related site or None
+
+    For standalone mode, will always return the site
+    For multisite mode, will return the site if there is a mapping between the
+    course and the site. Otherwise `None` is returned
+
+    # Implementation notes
+
+    There should be only one organization per course.
+    TODO: Figure out how we want to handle ``DoesNotExist``
+    whether to let it raise back up raw or handle with a custom exception
+    """
+    if figures.settings.is_multisite():
+        org_courses = organizations.models.OrganizationCourse.objects.filter(
+            course_id=str(course_id))
+        if org_courses:
+            # Keep until this assumption analyzed
+            msg = 'Multiple orgs found for course: {}'
+            assert org_courses.count() == 1, msg.format(course_id)
+            first_org = org_courses.first().organization
+            if hasattr(first_org, 'sites'):
+                msg = 'Must have one and only one site. Org is "{}"'
+                assert first_org.sites.count() == 1, msg.format(first_org.name)
+                site = first_org.sites.first()
+            else:
+                site = None
+        else:
+            # We don't want to make assumptions of who our consumers are
+            # TODO: handle no organizations found for the course
+            site = None
+    else:
+        # Operating in single site / standalone mode, return the default site
+        site = Site.objects.get(id=settings.SITE_ID)
+    return site
+
+
+def get_course_keys_for_site(site):
+    if figures.settings.is_multisite():
+        orgs = organizations.models.Organization.objects.filter(sites__in=[site])
+        org_courses = organizations.models.OrganizationCourse.objects.filter(
+            organization__in=orgs)
+        course_ids = org_courses.values_list('course_id', flat=True)
+    else:
+        course_ids = CourseOverview.objects.all().values_list('id', flat=True)
+    return [as_course_key(cid) for cid in course_ids]
+
+
+def get_courses_for_site(site):
+    """Returns the courses accessible by the user on the site
+
+    This function relies on Appsembler's fork of edx-organizations
+    """
+    if figures.settings.is_multisite():
+        course_keys = get_course_keys_for_site(site)
+        courses = CourseOverview.objects.filter(id__in=course_keys)
+    else:
+        courses = CourseOverview.objects.all()
+    return courses
+
+
+def get_user_ids_for_site(site):
+    if figures.settings.is_multisite():
+        orgs = organizations.models.Organization.objects.filter(sites__in=[site])
+        mappings = organizations.models.UserOrganizationMapping.objects.filter(
+            organization__in=orgs)
+        user_ids = mappings.values_list('user', flat=True)
+    else:
+        user_ids = get_user_model().objects.all().values_list('id', flat=True)
+    return user_ids
+
+
+def get_users_for_site(site):
+    if figures.settings.is_multisite():
+        user_ids = get_user_ids_for_site(site)
+        users = get_user_model().objects.filter(id__in=user_ids)
+    else:
+        users = get_user_model().objects.all()
+    return users
+
+
+def get_course_enrollments_for_site(site):
+    course_keys = get_course_keys_for_site(site)
+    return CourseEnrollment.objects.filter(course_id__in=course_keys)
+
+
+# MultipleObjectsReturned: get() returned more than one UserOrganizationMapping -- it returned 5!
+
+#  File "/edx/src/figures/figures/orgs.py", line 40, in get_users_for_site
+#    organization__in=orgs)

--- a/figures/views.py
+++ b/figures/views.py
@@ -3,6 +3,7 @@
 '''
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required, user_passes_test
+import django.contrib.sites.shortcuts
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.csrf import ensure_csrf_cookie

--- a/figures/views.py
+++ b/figures/views.py
@@ -2,8 +2,8 @@
 
 '''
 from django.contrib.auth import get_user_model
-from django.contrib.auth.decorators import login_required
-from django.contrib.auth.decorators import user_passes_test
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.csrf import ensure_csrf_cookie
 
@@ -11,6 +11,7 @@ from rest_framework import viewsets
 from rest_framework.authentication import (
     BasicAuthentication,
     SessionAuthentication,
+    TokenAuthentication,
 )
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.filters import DjangoFilterBackend
@@ -48,7 +49,9 @@ from .serializers import (
 )
 from figures import metrics
 from figures.pagination import FiguresLimitOffsetPagination
-from figures.permissions import IsStaffUser
+import figures.permissions
+import figures.settings
+import figures.sites
 
 
 UNAUTHORIZED_USER_REDIRECT_URL = '/'
@@ -60,7 +63,7 @@ UNAUTHORIZED_USER_REDIRECT_URL = '/'
 
 @ensure_csrf_cookie
 @login_required
-@user_passes_test(lambda u: u.is_active and (u.is_staff or u.is_superuser),
+@user_passes_test(lambda u: u.is_active,
                   login_url=UNAUTHORIZED_USER_REDIRECT_URL,
                   redirect_field_name=None)
 def figures_home(request):
@@ -70,6 +73,13 @@ def figures_home(request):
     TODO: Should we make this a view class?
 
     '''
+    # We probably want to roll this into a decorator
+    if figures.settings.is_multisite():
+        if not figures.permissions.is_site_admin_user(request):
+            return HttpResponseRedirect('/')
+    else:
+        if not figures.permissions.IsStaffUser().has_permission(request, view=None): 
+            return HttpResponseRedirect('/')
 
     # Placeholder context vars just to illustrate returning API hosts to the
     # client. This one uses a protocol relative url
@@ -85,10 +95,18 @@ def figures_home(request):
 
 class CommonAuthMixin(object):
     '''Provides a common authorization base for the Figures API views
-
+    TODO: Consider moving this to figures.permissions
     '''
-    authentication_classes = (BasicAuthentication, SessionAuthentication, )
-    permission_classes = (IsAuthenticated, IsStaffUser, )
+    authentication_classes = (
+        BasicAuthentication,
+        SessionAuthentication,
+        TokenAuthentication,
+    )
+    permission_classes = (
+        IsAuthenticated,
+        figures.permissions.IsStaffUser,
+        figures.permissions.IsSiteAdminUser,
+    )
 
 
 #
@@ -114,7 +132,6 @@ class CoursesIndexViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
 
     '''
     model = CourseOverview
-    queryset = CourseOverview.objects.all()
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = CourseIndexSerializer
 
@@ -122,10 +139,8 @@ class CoursesIndexViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     filter_class = CourseOverviewFilter
 
     def get_queryset(self):
-        '''
-
-        '''
-        queryset = super(CoursesIndexViewSet, self).get_queryset()
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        queryset = figures.sites.get_courses_for_site(site)
         return queryset
 
 
@@ -135,27 +150,29 @@ class UserIndexViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     Uses figures.filters.UserFilter to select subsets of User objects
     '''
     model = get_user_model()
-    queryset = get_user_model().objects.all()
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = UserIndexSerializer
     filter_backends = (DjangoFilterBackend, )
     filter_class = UserFilterSet
 
     def get_queryset(self):
-        queryset = super(UserIndexViewSet, self).get_queryset()
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        queryset = figures.sites.get_users_for_site(site)
         return queryset
 
 
 class CourseEnrollmentViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     model = CourseEnrollment
-    queryset = CourseEnrollment.objects.all()
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = CourseEnrollmentSerializer
     filter_backends = (DjangoFilterBackend, )
     filter_class = CourseEnrollmentFilter
 
     def get_queryset(self):
-        queryset = super(CourseEnrollmentViewSet, self).get_queryset()
+        # queryset = super(CourseEnrollmentViewSet, self).get_queryset()
+
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        queryset = figures.sites.get_course_enrollments_for_site(site)
         return queryset
 
 
@@ -166,28 +183,30 @@ class CourseEnrollmentViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
 class CourseDailyMetricsViewSet(CommonAuthMixin, viewsets.ModelViewSet):
 
     model = CourseDailyMetrics
-    queryset = CourseDailyMetrics.objects.all()
+    # queryset = CourseDailyMetrics.objects.all()
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = CourseDailyMetricsSerializer
     filter_backends = (DjangoFilterBackend, )
     filter_class = CourseDailyMetricsFilter
 
     def get_queryset(self):
-        queryset = super(CourseDailyMetricsViewSet, self).get_queryset()
+        # queryset = super(CourseDailyMetricsViewSet, self).get_queryset()
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        queryset = CourseDailyMetrics.objects.filter(site=site)
         return queryset
 
 
 class SiteDailyMetricsViewSet(CommonAuthMixin, viewsets.ModelViewSet):
 
     model = SiteDailyMetrics
-    queryset = SiteDailyMetrics.objects.all()
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = SiteDailyMetricsSerializer
     filter_backends = (DjangoFilterBackend, )
     filter_class = SiteDailyMetricsFilter
 
     def get_queryset(self):
-        queryset = super(SiteDailyMetricsViewSet, self).get_queryset()
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        queryset = SiteDailyMetrics.objects.filter(site=site)
         return queryset
 
 

--- a/figures/views.py
+++ b/figures/views.py
@@ -76,7 +76,7 @@ def figures_home(request):
 
     '''
     # We probably want to roll this into a decorator
-    if not figures.permissions.is_site_admin_user(request): 
+    if not figures.permissions.is_site_admin_user(request):
         return HttpResponseRedirect('/')
 
     # Placeholder context vars just to illustrate returning API hosts to the

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -11,7 +11,8 @@ import datetime
 from django.utils.timezone import utc
 
 from django.contrib.auth import get_user_model
-#from django_countries.fields import CountryField
+from django.contrib.sites.models import Site
+
 import factory
 from factory import fuzzy
 from factory.django import DjangoModelFactory
@@ -30,6 +31,13 @@ from figures.helpers import as_course_key
 from figures.models import CourseDailyMetrics, SiteDailyMetrics
 
 COURSE_ID_STR_TEMPLATE = 'course-v1:StarFleetAcademy+SFA{}+2161'
+
+
+class SiteFactory(DjangoModelFactory):
+    class Meta:
+        model = Site
+    domain = factory.Sequence(lambda n: 'site-{}.example.com'.format(n))
+    name = factory.Sequence(lambda n: 'Site {}'.format(n))
 
 
 class UserProfileFactory(DjangoModelFactory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -241,6 +241,7 @@ class CourseAccessRoleFactory(DjangoModelFactory):
 class CourseDailyMetricsFactory(DjangoModelFactory):
     class Meta:
         model = CourseDailyMetrics
+    site = factory.SubFactory(SiteFactory)
     date_for = factory.Sequence(lambda n:
         (datetime.datetime(2018, 1, 1) + datetime.timedelta(days=n)).replace(tzinfo=utc).date())
     course_id = factory.Sequence(lambda n:
@@ -255,6 +256,7 @@ class CourseDailyMetricsFactory(DjangoModelFactory):
 class SiteDailyMetricsFactory(DjangoModelFactory):
     class Meta:
         model = SiteDailyMetrics
+    site = factory.SubFactory(SiteFactory)
     date_for = factory.Sequence(lambda n:
         (datetime.datetime(2018, 1, 1) + datetime.timedelta(days=n)).replace(tzinfo=utc).date())
     cumulative_active_user_count = factory.Sequence(lambda n: n)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,8 @@
 
 from dateutil.rrule import rrule, DAILY
 
+import organizations
+
 
 def make_course_key_str(org, number, run='test-run', **kwargs):
     '''
@@ -13,3 +15,14 @@ def make_course_key_str(org, number, run='test-run', **kwargs):
 def create_metrics_model_timeseries(factory, first_day, last_day):
     return [factory(date_for=dt) 
         for dt in rrule(DAILY, dtstart=first_day, until=last_day)]
+
+
+def organizations_support_sites():
+    """
+    This function returns True if organizations supports site-organization
+    mapping, False otherwise.
+
+    This is used to conditionally run tests
+    """
+    orgs_has_site = hasattr(organizations.models.Organization, 'sites')
+    return orgs_has_site

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -446,7 +446,6 @@ class TestSiteMetricsGettersMultisite(object):
             start_date=self.data_start_date,
             end_date=self.data_end_date)
 
-        # import pdb; pdb.set_trace()
         assert count == len(student_module_sets)
 
     def test_get_total_site_users_for_time_period(self, env_tokens):

--- a/tests/models/test_course_daily_metrics_model.py
+++ b/tests/models/test_course_daily_metrics_model.py
@@ -30,16 +30,22 @@ class TestCourseDailyMetrics(object):
     def setup(self, db):
         '''Placeholder for test setup
         '''
-        pass
+        self.site = Site.objects.first()
 
     @pytest.mark.skip(
         reason="CourseKeyField not yet implemented in CourseDailyMetrics")
     def test_course_key(self):
         pass
 
-    @pytest.mark.parametrize('rec', [
-        dict(
-            date_for=datetime.date(2018, 02, 02),
+    def test_get_or_create(self):
+        '''Sanity check we can create the SiteDailyMetrics model
+
+        Create a second instance the way we'll do it in the production code.
+        Assert this is correct
+        '''
+        rec = dict(
+            site=self.site,
+            date_for=datetime.date(2018, 2, 2),
             course_id='course-v1:SomeOrg+ABC01+2121',
             defaults=dict(
                 enrollment_count=11,
@@ -48,15 +54,7 @@ class TestCourseDailyMetrics(object):
                 average_days_to_complete=5,
                 num_learners_completed=10
             ),
-        ),
-    ])
-    def test_get_or_create(self, rec):
-        '''Sanity check we can create the SiteDailyMetrics model
-
-        Create a second instance the way we'll do it in the production code.
-        Assert this is correct
-        '''
-
+        )
         metrics, created = CourseDailyMetrics.objects.get_or_create(**rec)
         assert metrics and created
         metrics2, created = CourseDailyMetrics.objects.get_or_create(**rec)
@@ -70,7 +68,8 @@ class TestCourseDailyMetrics(object):
         assert Site.objects.count() == 1
 
         rec_data = dict(
-            date_for=datetime.date(2018, 02, 02),
+            site=self.site,
+            date_for=datetime.date(2018, 2, 2),
             enrollment_count=11,
             active_learners_today=1,
             average_progress=0.5,
@@ -95,8 +94,14 @@ class TestCourseDailyMetrics(object):
         # Verify we deleted the correct metrics object
         assert obj == CourseDailyMetrics.objects.first()
 
-    @pytest.mark.parametrize('rec', [
-        dict(
+    def test_create_violates_unique(self, ):
+        '''Test CourseDailyMetrics unique constraints
+        First create a model instance, then try creating with the same
+        date_for and course_id. It should raise IntegrityError
+        '''
+
+        rec =  dict(
+            site=self.site,
             date_for=datetime.date(2018, 2, 2),
             course_id='course-v1:SomeOrg+ABC01+2121',
             enrollment_count=11,
@@ -104,13 +109,7 @@ class TestCourseDailyMetrics(object):
             average_progress=0.5,
             average_days_to_complete=5,
             num_learners_completed=10
-        ),
-    ])
-    def test_create_violates_unique(self, rec):
-        '''Test CourseDailyMetrics unique constraints
-        First create a model instance, then try creating with the same
-        date_for and course_id. It should raise IntegrityError
-        '''
+        )
         metrics = CourseDailyMetrics.objects.create(**rec)
         with pytest.raises(IntegrityError) as e_info:
             metrics = CourseDailyMetrics.objects.create(**rec)

--- a/tests/models/test_course_daily_metrics_model.py
+++ b/tests/models/test_course_daily_metrics_model.py
@@ -64,7 +64,8 @@ class TestCourseDailyMetrics(object):
         assert metrics2 == metrics
 
     def test_site(self):
-        """Tests expected CourseDailyMetrics behavior for working with a Site
+        """
+        Tests expected CourseDailyMetrics behavior for working with a Site
         """
         assert Site.objects.count() == 1
 

--- a/tests/models/test_course_daily_metrics_model.py
+++ b/tests/models/test_course_daily_metrics_model.py
@@ -97,7 +97,7 @@ class TestCourseDailyMetrics(object):
 
     @pytest.mark.parametrize('rec', [
         dict(
-            date_for=datetime.date(2018, 02, 02),
+            date_for=datetime.date(2018, 2, 2),
             course_id='course-v1:SomeOrg+ABC01+2121',
             enrollment_count=11,
             active_learners_today=1,

--- a/tests/models/test_learner_course_grade_metrics_model.py
+++ b/tests/models/test_learner_course_grade_metrics_model.py
@@ -5,6 +5,8 @@
 import datetime
 import pytest
 
+from django.contrib.sites.models import Site
+
 from figures.models import LearnerCourseGradeMetrics
 
 from tests.factories import CourseEnrollmentFactory
@@ -19,6 +21,7 @@ class TestLearnerCourseGradeMetrics(object):
     """
     @pytest.fixture(autouse=True)
     def setup(self, db):
+        self.site = Site.objects.first()
         self.date_for = datetime.date(2018, 2, 2)
         self.course_enrollment = CourseEnrollmentFactory()
         self.grade_data = dict(
@@ -29,6 +32,7 @@ class TestLearnerCourseGradeMetrics(object):
             )
         self.create_rec = self.grade_data.copy()
         self.create_rec.update(dict(
+            site=self.site,
             date_for=self.date_for,
             user=self.course_enrollment.user,
             course_id=self.course_enrollment.course_id))

--- a/tests/models/test_site_daily_metrics_model.py
+++ b/tests/models/test_site_daily_metrics_model.py
@@ -26,8 +26,15 @@ class TestSiteDailyMetrics(object):
 
         '''
 
-    @pytest.mark.parametrize('rec', [
-        dict(
+    def test_create(self):
+        '''Sanity check we can create the SiteDailyMetrics model
+
+        Create a second instance the way we'll do it in the production code.
+        Assert this is correct
+        '''
+
+        rec = dict(
+            site=Site.objects.first(),
             date_for=datetime.date(2018, 2, 2),
             defaults=dict(
                 cumulative_active_user_count=11,
@@ -35,26 +42,18 @@ class TestSiteDailyMetrics(object):
                 course_count=1,
                 total_enrollment_count=1
             ),
-        ),
-    ])
-    def test_create(self, rec):
-        '''Sanity check we can create the SiteDailyMetrics model
-
-        Create a second instance the way we'll do it in the production code.
-        Assert this is correct
-        '''
-
+        )
         site_metrics, created = SiteDailyMetrics.objects.get_or_create(**rec)
-
         assert created and site_metrics
 
-    def test_site(self):
+    def test_multiple_sites(self):
         """
         Tests expected SiteDailyMetrics behavior for working with a Site
         """
         assert Site.objects.count() == 1
         default_site = Site.objects.first()
         rec = dict(
+            site=Site.objects.first(),
             date_for=datetime.date(2018, 02, 02),
             cumulative_active_user_count=11,
             total_user_count=1,

--- a/tests/models/test_site_daily_metrics_model.py
+++ b/tests/models/test_site_daily_metrics_model.py
@@ -28,7 +28,7 @@ class TestSiteDailyMetrics(object):
 
     @pytest.mark.parametrize('rec', [
         dict(
-            date_for=datetime.date(2018,02,02),
+            date_for=datetime.date(2018, 2, 2),
             defaults=dict(
                 cumulative_active_user_count=11,
                 total_user_count=1,

--- a/tests/models/test_site_daily_metrics_model.py
+++ b/tests/models/test_site_daily_metrics_model.py
@@ -5,11 +5,12 @@
 import datetime
 import pytest
 
+from django.contrib.sites.models import Site
 from django.db.utils import IntegrityError
 
 from figures.models import SiteDailyMetrics
 
-from tests.factories import SiteDailyMetricsFactory
+from tests.factories import SiteFactory, SiteDailyMetricsFactory
 
 
 @pytest.mark.django_db
@@ -24,18 +25,6 @@ class TestSiteDailyMetrics(object):
         '''Placeholder for test setup
 
         '''
-        self.site_daily_metrics = [
-            SiteDailyMetricsFactory()
-        ]
-
-    def test_foo(self):
-        '''
-        Assert that SiteDailyMetricsFactory works by checking the object
-        created in this class's ``setup`` method.
-
-        '''
-        assert SiteDailyMetrics.objects.count() == 1
-
 
     @pytest.mark.parametrize('rec', [
         dict(
@@ -59,3 +48,31 @@ class TestSiteDailyMetrics(object):
 
         assert created and site_metrics
 
+    def test_site(self):
+        """
+        Tests expected SiteDailyMetrics behavior for working with a Site
+        """
+        assert Site.objects.count() == 1
+        default_site = Site.objects.first()
+        rec = dict(
+            date_for=datetime.date(2018, 02, 02),
+            cumulative_active_user_count=11,
+            total_user_count=1,
+            course_count=1,
+            total_enrollment_count=1
+        )
+        obj = SiteDailyMetrics.objects.create(**rec)
+        assert obj.site == default_site
+
+        alpha_site = SiteFactory(domain='alpha.example.com', name='Alpha')
+        assert Site.objects.count() == 2
+        rec['site'] = alpha_site
+        obj2 = SiteDailyMetrics.objects.create(**rec)
+        assert obj2.site == alpha_site
+
+        # Test cascade delete
+        assert SiteDailyMetrics.objects.count() == 2
+        alpha_site.delete()
+        assert SiteDailyMetrics.objects.count() == 1
+        # Verify we deleted the correct metrics object
+        assert obj == SiteDailyMetrics.objects.first()

--- a/tests/pipeline/test_course_daily_metrics.py
+++ b/tests/pipeline/test_course_daily_metrics.py
@@ -1,5 +1,6 @@
 """Tests the pipeline to extract data and populate the CourseDailyMetrics model
 
+TODO: Update this test module to test multisite environments
 """
 
 import datetime
@@ -13,6 +14,7 @@ from student.models import CourseEnrollment, CourseAccessRole
 from figures.helpers import as_datetime, next_day, prev_day
 from figures.models import PipelineError
 from figures.pipeline import course_daily_metrics as pipeline_cdm
+import figures.sites
 
 from tests.factories import (
     CourseAccessRoleFactory,
@@ -53,7 +55,7 @@ class TestGetCourseEnrollments(object):
             date_for=self.today).values_list('id', flat=True)
         assert set(results_ce) == set(expected_ce)
 
-
+# @mock.patch('figures.settings.env_tokens', return_value={'IS_FIGURES_MULTISITE': False})
 @pytest.mark.django_db
 class TestCourseDailyMetricsPipelineFunctions(object):
     """
@@ -111,23 +113,24 @@ class TestCourseDailyMetricsPipelineFunctions(object):
         """
 
         # Get the number of course enrollments
-        ce_count = CourseEnrollment.objects.filter(
-            course_id=self.course_overview.id).count()
-        # Get course admins (non-students)
-        ce_non_students = CourseAccessRole.objects.filter(
-            course_id=self.course_overview.id).count()
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            ce_count = CourseEnrollment.objects.filter(
+                course_id=self.course_overview.id).count()
+            # Get course admins (non-students)
+            ce_non_students = CourseAccessRole.objects.filter(
+                course_id=self.course_overview.id).count()
 
-        expected_count = ce_count - ce_non_students
-        assert ce_count > 0 and ce_non_students > 0 and expected_count > 0, 'say something'
+            expected_count = ce_count - ce_non_students
+            assert ce_count > 0 and ce_non_students > 0 and expected_count > 0, 'say something'
 
-        actual_count = pipeline_cdm.get_num_enrolled_in_exclude_admins(
-            course_id=self.course_overview.id, date_for=self.today)
+            actual_count = pipeline_cdm.get_num_enrolled_in_exclude_admins(
+                course_id=self.course_overview.id, date_for=self.today)
 
-        assert actual_count == expected_count
+            assert actual_count == expected_count
 
-        actual_count = pipeline_cdm.get_num_enrolled_in_exclude_admins(
-            course_id=str(self.course_overview.id), date_for=self.today)
-        assert actual_count == expected_count
+            actual_count = pipeline_cdm.get_num_enrolled_in_exclude_admins(
+                course_id=str(self.course_overview.id), date_for=self.today)
+            assert actual_count == expected_count
 
     def test_get_active_learner_ids_today(self):
         """
@@ -135,9 +138,10 @@ class TestCourseDailyMetricsPipelineFunctions(object):
         TODO: in the setup, add student module records modified in the past and
         add filtering to the expected_count here
         """
-        recs = pipeline_cdm.get_active_learner_ids_today(
-            course_id=self.course_overview.id, date_for=self.today)
-        assert recs.count() == len(self.course_enrollments)
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            recs = pipeline_cdm.get_active_learner_ids_today(
+                course_id=self.course_overview.id, date_for=self.today)
+            assert recs.count() == len(self.course_enrollments)
 
     def test_get_average_progress(self):
         """
@@ -146,67 +150,72 @@ class TestCourseDailyMetricsPipelineFunctions(object):
         just want to be able to set up the source data with expected output and
         go.
         """
-        course_enrollments = CourseEnrollment.objects.filter(
-            course_id=self.course_overview.id)
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            assert figures.settings.is_multisite() == False
+            course_enrollments = CourseEnrollment.objects.filter(
+                course_id=self.course_overview.id)
+            actual = pipeline_cdm.get_average_progress(
+                course_id=self.course_overview.id,
+                date_for=self.today,
+                course_enrollments=course_enrollments
+                )
+            # See tests/mocks/lms/djangoapps/grades/new/course_grade.py for
+            # the source subsection grades that
 
-        actual = pipeline_cdm.get_average_progress(
-            course_id=self.course_overview.id,
-            date_for=self.today,
-            course_enrollments=course_enrollments
-            )
-
-        # See tests/mocks/lms/djangoapps/grades/new/course_grade.py for
-        # the source subsection grades that
-
-        # TODO: make the mock data more configurable so we don't have to
-        # hardcode the expected value
-        assert actual == 0.5
+            # TODO: make the mock data more configurable so we don't have to
+            # hardcode the expected value
+            assert actual == 0.5
 
     @mock.patch(
         'figures.metrics.LearnerCourseGrades.course_progress',
         side_effect=PermissionDenied('mock-failure')
     )
     def test_get_average_progress_error(self, mock_lcg):
-        assert PipelineError.objects.count() == 0
-        course_enrollments = CourseEnrollment.objects.filter(
-            course_id=self.course_overview.id)
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            assert PipelineError.objects.count() == 0
+            course_enrollments = CourseEnrollment.objects.filter(
+                course_id=self.course_overview.id)
 
-        results = pipeline_cdm.get_average_progress(
+            results = pipeline_cdm.get_average_progress(
+                    course_id=self.course_overview.id,
+                    date_for=self.today,
+                    course_enrollments=course_enrollments
+                    )
+            assert results == pytest.approx(0.0)
+            assert PipelineError.objects.count() == course_enrollments.count()
+
+    def test_get_days_to_complete(self, ):
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            expected = dict(
+                days=self.cert_days_to_complete,
+                errors=[])
+
+            actual = pipeline_cdm.get_days_to_complete(
                 course_id=self.course_overview.id,
-                date_for=self.today,
-                course_enrollments=course_enrollments
-                )
-        assert results == pytest.approx(0.0)
-        assert PipelineError.objects.count() == course_enrollments.count()
+                date_for=self.today)
 
-    def test_get_days_to_complete(self):
-        expected = dict(
-            days=self.cert_days_to_complete,
-            errors=[])
-
-        actual = pipeline_cdm.get_days_to_complete(
-            course_id=self.course_overview.id,
-            date_for=self.today)
-
-        assert actual == expected
+            assert actual == expected
 
     def test_calc_average_days_to_complete(self):
-        actual = pipeline_cdm.calc_average_days_to_complete(
-            self.cert_days_to_complete)
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            actual = pipeline_cdm.calc_average_days_to_complete(
+                self.cert_days_to_complete)
 
-        assert actual == self.expected_avg_cert_days_to_complete
+            assert actual == self.expected_avg_cert_days_to_complete
 
     def test_get_average_days_to_complete(self):
-        actual = pipeline_cdm.get_average_days_to_complete(
-            course_id=self.course_overview.id,
-            date_for=self.today)
-        assert actual == self.expected_avg_cert_days_to_complete
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            actual = pipeline_cdm.get_average_days_to_complete(
+                course_id=self.course_overview.id,
+                date_for=self.today)
+            assert actual == self.expected_avg_cert_days_to_complete
 
     def test_get_num_learners_completed(self):
-        actual = pipeline_cdm.get_num_learners_completed(
-            course_id=self.course_overview.id,
-            date_for=self.today)
-        assert actual == len(self.generated_certificates)
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            actual = pipeline_cdm.get_num_learners_completed(
+                course_id=self.course_overview.id,
+                date_for=self.today)
+            assert actual == len(self.generated_certificates)
 
 
 @pytest.mark.django_db
@@ -238,6 +247,7 @@ class TestCourseDailyMetricsLoader(object):
         self.student_module = StudentModuleFactory()
 
     def test_load(self):
-        course_id = self.course_enrollments[0].course_id
-        results = pipeline_cdm.CourseDailyMetricsLoader(course_id).load()
-        assert results
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            course_id = self.course_enrollments[0].course_id
+            results = pipeline_cdm.CourseDailyMetricsLoader(course_id).load()
+            assert results

--- a/tests/pipeline/test_loaders.py
+++ b/tests/pipeline/test_loaders.py
@@ -6,6 +6,8 @@ modules: course_daily_metrics, site_daily_metrics
 import datetime
 import pytest
 
+from django.contrib.sites.models import Site
+
 from figures.models import LearnerCourseGradeMetrics
 import figures.pipeline.loaders
 
@@ -17,6 +19,7 @@ class TestSaveLearnerCourseGrades(object):
 
     @pytest.fixture(autouse=True)
     def setup(self, db):
+        self.site = Site.objects.first()
         self.date_for = datetime.date(2018, 2, 2)
         self.course_enrollment = CourseEnrollmentFactory()
         self.user = self.course_enrollment.user
@@ -31,10 +34,13 @@ class TestSaveLearnerCourseGrades(object):
         assert LearnerCourseGradeMetrics.objects.count() == 0
 
         obj, created = figures.pipeline.loaders.save_learner_course_grades(
+            site=self.site,
             date_for=self.date_for,
             course_enrollment=self.course_enrollment,
             course_progress_details=details)
         assert LearnerCourseGradeMetrics.objects.count() == 1
+        assert obj.site == self.site
+        assert obj.course_id == str(self.course_enrollment.course_id)
         assert obj.points_possible == details['points_possible']
         assert obj.points_earned == details['points_earned']
         assert obj.sections_worked == details['sections_worked']

--- a/tests/pipeline/test_site_daily_metrics.py
+++ b/tests/pipeline/test_site_daily_metrics.py
@@ -3,6 +3,7 @@
 TODO:
 
 * Add tests for the individual field extractors
+* Add test coverage for multisite mode
 '''
 
 import datetime
@@ -19,6 +20,7 @@ from openedx.core.djangoapps.content.course_overviews.models import (
 from figures.helpers import as_datetime, prev_day
 from figures.models import SiteDailyMetrics
 from figures.pipeline import site_daily_metrics as pipeline_sdm
+import figures.sites
 
 from tests.factories import (
     CourseDailyMetricsFactory,
@@ -85,6 +87,7 @@ class TestCourseDailyMetricsMissingCdm(object):
         '''
         '''
         self.date_for = DEFAULT_END_DATE
+        self.site = Site.objects.first()
         self.course_count = 4
         self.course_overviews = [CourseOverviewFactory(
             created=self.date_for) for i in range(self.course_count)]
@@ -94,8 +97,10 @@ class TestCourseDailyMetricsMissingCdm(object):
         '''
         [CourseDailyMetricsFactory(
             date_for=self.date_for,
+            site=self.site,
             course_id=course.id) for course in self.course_overviews]
         course_ids = pipeline_sdm.missing_course_daily_metrics(
+            site=self.site,
             date_for=self.date_for)
         assert course_ids == set([])
 
@@ -104,12 +109,17 @@ class TestCourseDailyMetricsMissingCdm(object):
         '''
         [
             CourseDailyMetricsFactory(
-                date_for=self.date_for, course_id=self.course_overviews[0].id),
+                date_for=self.date_for,
+                site=self.site,
+                course_id=self.course_overviews[0].id),
             CourseDailyMetricsFactory(
-                date_for=self.date_for, course_id=self.course_overviews[1].id),
+                date_for=self.date_for,
+                site=self.site,
+                course_id=self.course_overviews[1].id),
         ]
         expected_missing = [unicode(co.id) for co in self.course_overviews[2:]]
-        actual = pipeline_sdm.missing_course_daily_metrics(date_for=self.date_for)
+        actual = pipeline_sdm.missing_course_daily_metrics(
+            site=self.site, date_for=self.date_for)
         assert actual == set(expected_missing)
 
 
@@ -121,7 +131,9 @@ class TestCourseDailyMetricsPipelineFunctions(object):
     @pytest.fixture(autouse=True)
     def setup(self, db):
         self.date_for = datetime.date(2018, 6, 1)
+        self.site = Site.objects.first()
         self.cdm_recs = [CourseDailyMetricsFactory(
+            site=self.site,
             date_for=self.date_for,
             **cdm
             ) for cdm in CDM_INPUT_TEST_DATA]
@@ -129,6 +141,7 @@ class TestCourseDailyMetricsPipelineFunctions(object):
     def test_get_active_user_count_for_date(self):
         expected = SDM_EXPECTED_RESULTS['todays_active_user_count']
         actual = pipeline_sdm.get_active_user_count_for_date(
+            site=self.site,
             date_for=self.date_for)
         assert actual == expected
 
@@ -139,15 +152,19 @@ class TestCourseDailyMetricsPipelineFunctions(object):
     def test_get_previous_cumulative_active_user_count(self, prev_day_data, expected):
         if prev_day_data:
             SiteDailyMetricsFactory(
+                site=self.site,
                 date_for=prev_day(self.date_for),
                 **prev_day_data)
         actual = pipeline_sdm.get_previous_cumulative_active_user_count(
+            site=self.site,
             date_for=self.date_for)
         assert actual == expected
 
     def test_get_total_enrollment_count(self):
         expected = SDM_EXPECTED_RESULTS['total_enrollment_count']
-        actual = pipeline_sdm.get_total_enrollment_count(date_for=self.date_for)
+        actual = pipeline_sdm.get_total_enrollment_count(
+            site=self.site,
+            date_for=self.date_for)
         assert actual == expected
 
 
@@ -159,6 +176,7 @@ class TestSiteDailyMetricsExtractor(object):
     @pytest.fixture(autouse=True)
     def setup(self, db):
         self.date_for = datetime.date(2018, 10, 1)
+        self.site = Site.objects.first()
         self.users = [UserFactory(
             date_joined=as_datetime(self.date_for - datetime.timedelta(days=60))
             ) for i in range(0, 3)]
@@ -166,10 +184,12 @@ class TestSiteDailyMetricsExtractor(object):
             created=as_datetime(self.date_for - datetime.timedelta(days=60))
             ) for i in range(0, 3)]
         self.cdm_recs = [CourseDailyMetricsFactory(
+            site=self.site,
             date_for=self.date_for,
             **cdm
             ) for cdm in CDM_INPUT_TEST_DATA]
         self.prev_day_sdm = SiteDailyMetricsFactory(
+            site=self.site,
             date_for=prev_day(self.date_for),
             **SDM_PREV_DAY[1])
 
@@ -182,19 +202,20 @@ class TestSiteDailyMetricsExtractor(object):
             total_enrollment_count=150,
         )
 
-        for course in CourseOverview.objects.all():
+        for course in figures.sites.get_courses_for_site(self.site):
             assert course.created.date() < self.date_for
-        for user in get_user_model().objects.all():
+        for user in figures.sites.get_users_for_site(self.site):
             assert user.date_joined.date() < self.date_for
 
         actual = pipeline_sdm.SiteDailyMetricsExtractor().extract(
+            site=self.site,
             date_for=self.date_for)
         for key, value in expected_results.iteritems():
             assert actual[key] == value, 'failed on key: "{}"'.format(key)
 
 
 @pytest.mark.django_db
-class TestSiteDailyMetricsLoaderSingleSite(object):
+class TestSiteDailyMetricsLoader(object):
     """
     Tests the site metrics loading for single site (standalone) deployments
 
@@ -209,7 +230,7 @@ class TestSiteDailyMetricsLoaderSingleSite(object):
 
     class MockExtractor(object):
         def extract(self, **kwargs):
-            return TestSiteDailyMetricsLoaderSingleSite.FIELD_VALUES
+            return TestSiteDailyMetricsLoader.FIELD_VALUES
 
     @pytest.fixture(autouse=True)
     def setup(self, db):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,8 +14,9 @@ from figures import settings as figures_settings
 
 
 @pytest.mark.parametrize('env_tokens, expected ', [
-        ({'IS_MULTISITE': True}, True),
-        ({'IS_MULTISITE': False}, False),
+        ({'IS_FIGURES_MULTISITE': True}, True),
+        ({'IS_FIGURES_MULTISITE': False}, False),
+        ({}, False),
     ])
 def test_is_multisite(env_tokens, expected):
     """
@@ -23,13 +24,6 @@ def test_is_multisite(env_tokens, expected):
     """
     with mock.patch('figures.settings.env_tokens', env_tokens):
         assert figures_settings.is_multisite() == expected
-
-
-def test_is_multisite_default():
-    """
-    Just test that the default behavior is multisite is disabled in settings
-    """
-    assert not figures_settings.is_multisite()
 
 
 @pytest.mark.parametrize('env_tokens, expected ', [

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,6 +14,25 @@ from figures import settings as figures_settings
 
 
 @pytest.mark.parametrize('env_tokens, expected ', [
+        ({'IS_MULTISITE': True}, True),
+        ({'IS_MULTISITE': False}, False),
+    ])
+def test_is_multisite(env_tokens, expected):
+    """
+    Test env_tokens work properly for Figures multisite settings
+    """
+    with mock.patch('figures.settings.env_tokens', env_tokens):
+        assert figures_settings.is_multisite() == expected
+
+
+def test_is_multisite_default():
+    """
+    Just test that the default behavior is multisite is disabled in settings
+    """
+    assert not figures_settings.is_multisite()
+
+
+@pytest.mark.parametrize('env_tokens, expected ', [
         ({'LOG_PIPELINE_ERRORS_TO_DB': True}, True),
         ({'LOG_PIPELINE_ERRORS_TO_DB': False}, False),
     ])

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,0 +1,287 @@
+"""
+Tests Figures multisite/standalone site support handlers
+
+The multisite tests require Appsembler's fork of edx-organizations installed
+
+The test classes in this module handle the following conditions
+* Standalone mode (run regardless if organizations supports sites)
+* Multisite mode when organizations supports sites
+* Multisite mode when organizations does not support sites
+
+Current structure
+=================
+
+We're structuring the test classes around the data setup required so that we're
+minimizing extra data set up:
+
+* Single test class for standalone mode
+* Multiple test classes for multisite mode
+
+TODOs: Create base test class for the multisite setup (and teardown if needed)
+or restructure into fixtures and standalone test functions, depending on how
+figures.sites evolves
+"""
+
+import mock
+import pytest
+
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+
+import organizations
+
+from openedx.core.djangoapps.content.course_overviews.models import (
+    CourseOverview,
+)
+
+import figures.settings
+import figures.sites
+
+from tests.factories import (
+    CourseEnrollmentFactory,
+    CourseOverviewFactory,
+    OrganizationFactory,
+    OrganizationCourseFactory,
+    SiteFactory,
+    UserFactory,
+    # Appsembler specific
+    # UserOrganizationMappingFactory,
+)
+from tests.helpers import organizations_support_sites
+
+
+if organizations_support_sites():
+    from tests.factories import UserOrganizationMappingFactory
+
+
+@pytest.mark.django_db
+class TestHandlersForStandaloneMode(object):
+    """
+    Tests figures.sites site handling functions in standalone site mode
+    These tests should pass regardless of whether or not and if so how
+    organizations supports organization-site mapping
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.default_site = Site.objects.get()
+        self.env_tokens = {'IS_FIGURES_MULTISITE': False}
+        self.site = Site.objects.first()
+        assert Site.objects.count() == 1
+        assert not figures.settings.is_multisite()
+
+    def test_get_site_for_course(self):
+        """
+
+        """
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            co = CourseOverviewFactory()
+            site = figures.sites.get_site_for_course(str(co.id))
+            assert site == Site.objects.first()
+
+    @pytest.mark.parametrize('course_count', [0, 1, 2])
+    def test_get_course_keys_for_site(self, course_count):
+        sites = Site.objects.all()
+        assert sites.count() == 1
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            course_overviews = [CourseOverviewFactory() for i in range(course_count)]
+            course_keys = figures.sites.get_course_keys_for_site(sites[0])
+            expected_ids = [str(co.id) for co in course_overviews]
+            assert set([str(key) for key in course_keys]) == set(expected_ids)
+
+    def test_get_courses_for_site(self):
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            courses = figures.sites.get_courses_for_site(self.site)
+            assert set(courses) == set(CourseOverview.objects.all())
+
+    def test_get_user_ids_for_site(self):
+        expected_users = [UserFactory() for i in range(3)]
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            user_ids = figures.sites.get_user_ids_for_site(self.site)
+            assert set(user_ids) == set([user.id for user in expected_users])
+
+    def test_get_users_for_site(self):
+        expected_users = [UserFactory() for i in range(3)]
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            users = figures.sites.get_users_for_site(self.site)
+            assert set([user.id for user in users]) == set(
+                       [user.id for user in expected_users])
+
+    def test_get_course_enrollments_for_site(self):
+        expected_ce = [CourseEnrollmentFactory() for i in range(3)]
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            course_enrollments = figures.sites.get_course_enrollments_for_site(self.site)
+            assert set([ce.id for ce in course_enrollments]) == set(
+                       [ce.id for ce in expected_ce])
+
+
+@pytest.mark.skipif(not organizations_support_sites(),
+                    reason='Organizations support sites')
+@pytest.mark.django_db
+class TestHandlersForMultisiteMode(object):
+    """
+    Tests figures.sites site handling functions in multisite mode
+
+    Assumptions:
+    * We're using Appsembler's fork of `edx-organizations` for the multisite
+      tests
+
+    """
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.site = SiteFactory(domain='foo.test')
+        self.organization = OrganizationFactory(sites=[self.site])
+        assert Site.objects.count() == 2
+        self.env_tokens = {'IS_FIGURES_MULTISITE': True}
+
+    def test_get_site_for_courses(self):
+        """
+        Can we get the site for a given course?
+
+        We shouldn't care what the other site is. For reference, it is the
+        default site with 'example.com' for both the domain and name fields
+        """
+        # We want to move the patch to the class level if possible
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            assert figures.settings.is_multisite()
+            co = CourseOverviewFactory()
+            OrganizationCourseFactory(organization=self.organization,
+                                      course_id=str(co.id))
+            site = figures.sites.get_site_for_course(str(co.id))
+            assert site == self.site
+
+    def test_get_site_for_course_not_in_site(self):
+        """
+        We create a course but don't add the course to OrganizationCourse
+        We expect that a site cannot be found
+        """
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            assert figures.settings.is_multisite()
+            co = CourseOverviewFactory()
+            site = figures.sites.get_site_for_course(str(co.id))
+            assert not site
+
+    @pytest.mark.parametrize('course_id', ['', None])
+    def test_get_site_for_non_existing_course(self, course_id):
+        """
+        We expect no site returned for None for the course
+        """
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            assert figures.settings.is_multisite()
+            site = figures.sites.get_site_for_course(course_id)
+            assert not site
+
+    @pytest.mark.parametrize('course_count', [0, 1, 2])
+    def test_get_course_keys_for_site(self, course_count):
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            assert figures.settings.is_multisite()
+            course_overviews = [CourseOverviewFactory() for i in range(course_count)]
+            for co in course_overviews:
+                OrganizationCourseFactory(organization=self.organization,
+                                          course_id=str(co.id))
+            course_keys = figures.sites.get_course_keys_for_site(self.site)
+            expected_ids = [str(co.id) for co in course_overviews]
+            assert set([str(key) for key in course_keys]) == set(expected_ids)
+
+    @pytest.mark.parametrize('course_count', [0, 1, 2])
+    def test_get_courses_for_site(self, course_count):
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            assert figures.settings.is_multisite()
+            course_overviews = [CourseOverviewFactory() for i in range(course_count)]
+            for co in course_overviews:
+                OrganizationCourseFactory(organization=self.organization,
+                                          course_id=str(co.id))
+            courses = figures.sites.get_courses_for_site(self.site)
+            expected_ids = [str(co.id) for co in course_overviews]
+            assert set([str(co.id) for co in courses]) == set(expected_ids)
+
+    @pytest.mark.parametrize('ce_count', [0, 1, 2])
+    def test_get_course_enrollments_for_site(self, ce_count):
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            assert figures.settings.is_multisite()
+            course_overview = CourseOverviewFactory()
+            OrganizationCourseFactory(organization=self.organization,
+                                      course_id=str(course_overview.id))
+            expected_ce = [CourseEnrollmentFactory(
+                course_id=course_overview.id) for i in range(ce_count)]
+            course_enrollments = figures.sites.get_course_enrollments_for_site(self.site)
+            assert set([ce.id for ce in course_enrollments]) == set(
+                       [ce.id for ce in expected_ce])
+
+
+@pytest.mark.skipif(not organizations_support_sites(),
+                    reason='Organizations support sites')
+@pytest.mark.django_db
+class TestUserHandlersForMultisiteMode(object):
+    """
+    Tests figures.sites site handling functions in multisite mode
+
+    Test does not yet provide multiple sites/orgs to test leakiness
+
+    Assumptions:
+    * We're using Appsembler's fork of `edx-organizations` for the multisite
+      tests
+
+    """
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.site = SiteFactory(domain='foo.test')
+        self.organization = OrganizationFactory(
+            sites=[self.site],
+        )
+        assert get_user_model().objects.count() == 0
+        self.users = [UserFactory() for i in range(3)]
+        for user in self.users:
+            UserOrganizationMappingFactory(user=user,
+                                           organization=self.organization)
+        assert Site.objects.count() == 2
+        self.env_tokens = {'IS_FIGURES_MULTISITE': True}
+
+    def test_get_user_ids_for_site(self):
+        expected_users = self.users
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            user_ids = figures.sites.get_user_ids_for_site(self.site)
+            assert set(user_ids) == set([user.id for user in expected_users])
+
+    def test_get_users_for_site(self):
+        expected_users = self.users
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            users = figures.sites.get_users_for_site(self.site)
+            assert set([user.id for user in users]) == set(
+                       [user.id for user in expected_users])
+
+
+@pytest.mark.skipif(organizations_support_sites(),
+                    reason='Organizations package does not support sites')
+@pytest.mark.django_db
+class TestOrganizationsLacksSiteSupport(object):
+    """
+    This class tests how the figures.sites module handles multisite mode when
+    organizations models do not associate organizations with sites
+
+    TODO: Improve test coverage
+    """
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.site = SiteFactory(domain='foo.test')
+        assert Site.objects.count() == 2
+        self.env_tokens = {'IS_FIGURES_MULTISITE': True}
+
+    def test_create_organiztion_with_site(self):
+        """
+        Make sure that we cannot associate an organization with a site
+
+        Another way to check is if organizations.models.Organization has the
+        'sites' field via `hasattr`
+        """
+        with pytest.raises(TypeError):
+            OrganizationFactory(sites=[self.site])
+
+    def test_org_course_missing_sites_field(self):
+
+        with mock.patch('figures.settings.env_tokens', self.env_tokens):
+            # orgs = organizations.models.Organization.objects.all()
+            # assert orgs
+            # msg = 'Not supposed to have "sites" attribute'
+            assert not hasattr(
+                organizations.models.Organization, 'sites'), msg

--- a/tests/views/base.py
+++ b/tests/views/base.py
@@ -1,8 +1,12 @@
+"""
 
+TODO: Add test coverage for multisite
+"""
+import mock
 import pytest
 
 from django.contrib.auth import get_user_model
-
+from django.contrib.sites.models import Site
 from rest_framework.test import (
     APIRequestFactory,
     #RequestsClient, Not supported in older  rest_framework versions
@@ -22,6 +26,7 @@ class BaseViewTest(object):
     @pytest.fixture(autouse=True)
     def setup(self, db):
         self.callers = create_test_users()
+        self.site = Site.objects.first()
 
 
     @pytest.mark.skip()
@@ -31,7 +36,7 @@ class BaseViewTest(object):
         ('super_user', 200),
         ('superstaff_user', 200),
     ])
-    def test_get_authentication(self, username, status_code):
+    def test_get_authentication_standalone_mode(self, username, status_code):
         '''
         Provides authentication testing
         Tests in the inherited classes provide for testing results
@@ -40,18 +45,19 @@ class BaseViewTest(object):
         Django Rest Framework ViewSetMixin class. This requires
         the action in the 'as_view' call
         '''
-        request = APIRequestFactory().get(self.request_path)
-        user = get_user_model().objects.get(username=username)
-        force_authenticate(request, user=user)
+        with mock.patch.dict('figures.settings.env_tokens', {'IS_FIGURES_MULTISITE': False}):
+            request = APIRequestFactory().get(self.request_path)
+            user = get_user_model().objects.get(username=username)
+            force_authenticate(request, user=user)
 
-        # This is a (temporary we hope) hack to support views
-        # that can be derived from either APIView or ViewSetMixin
-        if self.get_action:
-            view = self.view_class.as_view(self.get_action)
-        else:
-            view = self.view_class.as_view()
-        response = view(request)
-        assert response.status_code == status_code
+            # This is a (temporary we hope) hack to support views
+            # that can be derived from either APIView or ViewSetMixin
+            if self.get_action:
+                view = self.view_class.as_view(self.get_action)
+            else:
+                view = self.view_class.as_view()
+            response = view(request)
+            assert response.status_code == status_code
 
     @property
     def staff_user(self):

--- a/tests/views/test_course_daily_metrics_view.py
+++ b/tests/views/test_course_daily_metrics_view.py
@@ -64,8 +64,8 @@ class TestCourseDailyMetricsView(BaseViewTest):
         assert response_data['date_for'] == str(obj.date_for)
         assert parse(response_data['created']) == obj.created
         assert parse(response_data['modified']) == obj.modified
-
-        for field_name in (self.expected_results_keys - self.date_fields):
+        check_fields = self.expected_results_keys - self.date_fields - set(['site'])
+        for field_name in check_fields:
             obj_field = getattr(obj, field_name)
             if (type(response_data) in (float, Decimal,) or 
                 type(obj_field) in (float, Decimal,)):

--- a/tests/views/test_figures_home_view.py
+++ b/tests/views/test_figures_home_view.py
@@ -64,7 +64,6 @@ class TestFiguresHomeView(object):
         request = self.factory.get(reverse('figures-home'))
         request.user = get_user_model().objects.get(username=username)
         response = figures_home(request)
-        assert response.status_code == status_code
+        assert response.status_code == status_code, "username={}".format(username)
         if status_code == 302:
             assert response['location'] == UNAUTHORIZED_USER_REDIRECT_URL
-

--- a/tests/views/test_site_daily_metrics_view.py
+++ b/tests/views/test_site_daily_metrics_view.py
@@ -108,10 +108,8 @@ class TestSiteDailyMetricsView(BaseViewTest):
             assert data['date_for'] == str(db_rec.date_for)
             assert parse(data['created']) == db_rec.created
             assert parse(data['modified']) == db_rec.modified
-
-        field_names = self.expected_results_keys - self.date_fields
-
-        for field_name in (self.expected_results_keys - self.date_fields):
+        check_fields = self.expected_results_keys - self.date_fields - set(['site'])
+        for field_name in check_fields:
             assert data[field_name] == getattr(db_rec,field_name)
 
     # @pytest.mark.parametrize('username, status_code', [

--- a/tests/views/test_site_daily_metrics_view.py
+++ b/tests/views/test_site_daily_metrics_view.py
@@ -18,7 +18,7 @@ from rest_framework.test import (
 from figures.models import SiteDailyMetrics
 from figures.pagination import FiguresLimitOffsetPagination
 from figures.views import SiteDailyMetricsViewSet
-
+from figures.serializers import SiteSerializer
 from tests.factories import SiteDailyMetricsFactory, UserFactory
 from tests.views.base import BaseViewTest
 
@@ -28,9 +28,9 @@ TEST_DATA = [
 
 ]
 
-def generate_sdm_series(first_day, last_day):
+def generate_sdm_series(site, first_day, last_day):
 
-    return [SiteDailyMetricsFactory(date_for=dt) 
+    return [SiteDailyMetricsFactory(site=site, date_for=dt) 
         for dt in rrule(DAILY, dtstart=first_day, until=last_day)]
 
 
@@ -61,7 +61,7 @@ class TestSiteDailyMetricsView(BaseViewTest):
         field_names = (o.name for o in SiteDailyMetrics._meta.fields
             if o.name not in self.date_fields )
 
-        self.metrics = generate_sdm_series(self.first_day, self.last_day)
+        self.metrics = generate_sdm_series(self.site, self.first_day, self.last_day)
 
     def test_get_last_day(self):
         pass
@@ -112,24 +112,20 @@ class TestSiteDailyMetricsView(BaseViewTest):
         for field_name in check_fields:
             assert data[field_name] == getattr(db_rec,field_name)
 
-    # @pytest.mark.parametrize('username, status_code', [
-    #     ('regular_user', 403),
-    #     ('staff_user', 200),
-    #     ('super_user', 200),
-    #     ('superstaff_user', 200),
-    # ])
-    # def test_get_authentication(self, username, status_code):
-    #     factory = APIRequestFactory()
-    #     request = factory.get('api/site-daily-metrics')
-    #     user = get_user_model().objects.get(username='staff_user')
-    #     force_authenticate(request, user=user)
-    #     view = SiteDailyMetricsViewSet.as_view({'get':'list'})
-    #     response = view(request)
-    #     assert response.status_code == 200
+    @pytest.mark.xfail
+    def test_create(self):
+        """
+        When adding the site serialized data, this test fails with:
+            AssertionError: The `.create()` method does not support writable
+            nestedfields by default.
+            Write an explicit `.create()` method for serializer
+            `figures.serializers.SiteDailyMetricsSerializer`, or set `read_only=True`
+            on nested serializer fields.
 
-
-    @pytest.mark.parametrize('data', [
-        ( dict(
+        Note: We don't need write functionality with this view as of version 0.2.0
+        """
+        data = dict(
+            # site=SiteSerializer(self.site).data,
             date_for='2020-01-01',
             cumulative_active_user_count=1,
             todays_active_user_count=2,
@@ -137,10 +133,6 @@ class TestSiteDailyMetricsView(BaseViewTest):
             course_count=4,
             total_enrollment_count=5
             )
-        ),
-    ])
-    def test_create(self, data):
-
         # Might not need to set format='json'
         request = APIRequestFactory().post(
             self.request_path, data, format='json')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = 
+	py27-appsembler_orgs
+	py27-edx_orgs
+
+[pytest]
+
+[testenv]
+deps =
+	appsembler_orgs: -r{toxinidir}/devsite/requirements.txt
+	edx_orgs: -r{toxinidir}/devsite/edx_orgs_requirements.txt
+setenv =
+	DJANGO_SETTINGS_MODULE = devsite.test_settings
+	PYTHONPATH = {toxinidir}
+commands = pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,16 @@
 
 [tox]
 envlist = 
-	py27-appsembler_orgs
-	py27-edx_orgs
+	py27-openedx_ginkgo
+	py27-appsembler_multisite
 
 [pytest]
 
 [testenv]
 deps =
-	appsembler_orgs: -r{toxinidir}/devsite/requirements.txt
-	edx_orgs: -r{toxinidir}/devsite/edx_orgs_requirements.txt
+	openedx_ginkgo: -r{toxinidir}/devsite/requirements/base.txt
+	appsembler_multisite: -r{toxinidir}/devsite/requirements/appsembler_multisite.txt
+	
 setenv =
 	DJANGO_SETTINGS_MODULE = devsite.test_settings
 	PYTHONPATH = {toxinidir}


### PR DESCRIPTION
Production code + tests for review

# Context - Support both single site and multisite deployments

The code needs to support both single site and multisite deployments. Since single site deployments do not filter "per site" in queries, we can make 'Site' FKs mandatory for Figures metrics models and assign the default site for single site deployments. The other option considered is making the Site FK optional. 

# Up for review

*  Added settings handling, tests
* Added Site to metrics models
* Pipeline is now site aware. Populate sets of metrics per site. Initially will run all sites in sequence instead of as Celery subtasks. That will be a follow-on
* Added `sites` module as an facade to retrieve site filtered data
** Add awareness for custom `edx-organizations` (namely Appsembler's fork)
* Add multisite authentication and authorization to permissions module
* Add multisite support to views


The following items should not block getting Figures installed on Tahoe staging for testing, however, we *do* want to get this test coverage as we deploy to production

* Multisite test coverage for views
* Better testing for data leaking
