### PR TITLE
allow for sass options to be passed as part of the yarn build command

### DIFF
--- a/frontend/config/webpack.config.dev.js
+++ b/frontend/config/webpack.config.dev.js
@@ -204,12 +204,18 @@ module.exports = {
               loader: 'css-loader',
               options: {
                 modules: true,
+                data: "$primary-color: #ff0000",
                 sourceMap: true,
                 importLoaders: 2,
                 localIdentName: '[local]__[hash:base64:8]'
               }
             },
-            'sass-loader'
+            {
+              loader: 'sass-loader',
+              options: {
+                data: "" + (process.env.PRIMARY_COLOR ? ("$primary-color: " + process.env.PRIMARY_COLOR + "; ") : "") + (process.env.REM_BASE ? ("$rem-base-size: " + process.env.REM_BASE + ";") : "") + (process.env.BASE_FONT_SIZE ? ("$base-font-size: " + process.env.BASE_FONT_SIZE + ";") : "") + (process.env.BASE_TEXT_COLOR ? ("$base-text-color: " + process.env.BASE_TEXT_COLOR + ";") : ""),
+              }
+            },
           ]
         })
       },

--- a/frontend/config/webpack.config.prod.js
+++ b/frontend/config/webpack.config.prod.js
@@ -221,7 +221,12 @@ module.exports = {
                 localIdentName: '[local]__[hash:base64:8]'
               }
             },
-            'sass-loader'
+            {
+              loader: 'sass-loader',
+              options: {
+                data: "" + (process.env.PRIMARY_COLOR ? ("$primary-color: " + process.env.PRIMARY_COLOR + "; ") : "") + (process.env.REM_BASE ? ("$rem-base-size: " + process.env.REM_BASE + ";") : "") + (process.env.BASE_FONT_SIZE ? ("$base-font-size: " + process.env.BASE_FONT_SIZE + ";") : "") + (process.env.BASE_TEXT_COLOR ? ("$base-text-color: " + process.env.BASE_TEXT_COLOR + ";") : ""),
+              }
+            },
           ]
         })
       },

--- a/frontend/src/sass/base/_variables.scss
+++ b/frontend/src/sass/base/_variables.scss
@@ -1,15 +1,15 @@
 @import '~base/sass/base/functions';
 
-$rem-base-size: 16;
-$base-font-size: calcRem(14);
+$rem-base-size: 16 !default;
+$base-font-size: calcRem(14) !default;
 $max-grid-width: calcRem(1180);
 $mobile-breakpoint: calcRem(420);
 $tablet-breakpoint: calcRem(1020);
 
 $font-family: 'Open Sans', sans-serif;
 
-$primary-color: #259ED7;
-$base-text-color: #2C2A2F;
+$primary-color: #259ED7 !default;
+$base-text-color: #2C2A2F !default;
 
 $positive-color: #27ae60;
 $negative-color: #c0392b;


### PR DESCRIPTION
This PR addresses the issue of changing certain sass variables on a case-by-case deployment basis without requiring to do any maintenance of additional branches nor changing any source files upon deployment. The core issue that led to this implementation was the rem base issue: the default Open edX LMS frontend has a rem base of 16px, while certain (Appsembler) themes use 10px as their basis. This would cause the deployed app in those themes to appear with tiny element sizes. The issue is resolved by setting the variables in the app sass file as defaults, and configuring webpack in a way that allows for env variables to be passed and used as overrides of certain sass variables.

This means we can now override the following sass variables on build time, as part of the build command: `PRIMARY_COLOR`, `BASE_TEXT_COLOR`, `REM_BASE`, `BASE_FONT_SIZE`. Here is an example of how these can be applied upon build time:

`PRIMARY_COLOR=#00ffff BASE_TEXT_COLOR=#0000ff BASE_TEXT_SIZE=calcRem(18) REM_BASE=10 yarn build`

What's important to be noted is that they **don't necessarily need to be passed**. That means that you can just do `yarn build` to use the defaults from `_variables.scss`, or do any combination such as `REM_BASE=14 yarn build`, `PRIMARY_COLOR=#0090c1 yarn build`, `REM_BASE=14 PRIMARY_COLOR=#0090c1 yarn build`... to just override any certain variable(s).

Screenshots that show what this does follow:

(Default on vanilla Open edX)
![default](https://user-images.githubusercontent.com/10602234/50446744-e2c4f580-0916-11e9-8a61-0ad9805cd70a.jpg)

(Default on themed Open edX)
![default-with-theme](https://user-images.githubusercontent.com/10602234/50446748-eb1d3080-0916-11e9-91cf-3cc884e906b3.jpg)

(Command)
![command](https://user-images.githubusercontent.com/10602234/50446754-f1131180-0916-11e9-8639-03cf5b660cc7.jpg)

(Built with variables passed, rendered in theme)
![passed-variables-with-theme](https://user-images.githubusercontent.com/10602234/50446766-fc663d00-0916-11e9-9bdd-b55631a6d1cf.jpg)
