### PR TITLE
Pipeline fixes, logging and error handling improvements

### DIFF
--- a/figures/migrations/0007_modify_course_daily_metrics.py
+++ b/figures/migrations/0007_modify_course_daily_metrics.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('figures', '0006_remove_default_site_from_models'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='coursedailymetrics',
+            name='average_progress',
+            field=models.DecimalField(blank=True, null=True, max_digits=3, decimal_places=2, validators=[django.core.validators.MaxValueValidator(1.0), django.core.validators.MinValueValidator(0.0)]),
+        ),
+    ]

--- a/figures/models.py
+++ b/figures/models.py
@@ -4,6 +4,7 @@
 
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -33,7 +34,10 @@ class CourseDailyMetrics(TimeStampedModel):
     active_learners_today = models.IntegerField()
     # Do we want cumulative average progress for the month?
     average_progress = models.DecimalField(
-        max_digits=2, decimal_places=2, blank=True, null=True)
+        max_digits=3, decimal_places=2, blank=True, null=True,
+        validators=[MaxValueValidator(1.0), MinValueValidator(0.0)],
+        )
+
     average_days_to_complete = models.IntegerField(blank=True, null=True)
     num_learners_completed = models.IntegerField()
 

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -8,6 +8,8 @@ This module performs the following:
 
 The extractors work locally on the LMS
 Future: add a remote mode to pull data via REST API
+
+# TODO: Move extractors to figures.pipeline.extract module
 """
 import datetime
 import logging
@@ -32,11 +34,6 @@ import figures.sites
 
 logger = logging.getLogger(__name__)
 
-# TODO: Move extractors to figures.pipeline.extract module
-
-
-class InvalideCourseAverageProgress(Exception):
-    pass
 
 #
 # Extraction helper methods

--- a/figures/pipeline/logger.py
+++ b/figures/pipeline/logger.py
@@ -12,26 +12,29 @@ from django.core.serializers.json import DjangoJSONEncoder
 from figures.models import PipelineError
 from figures import settings
 
-logger = logging.getLogger(__name__)
+default_logger = logging.getLogger(__name__)
+
+
+def log_error_to_db(error_data, error_type, **kwargs):
+    data = dict(
+        error_data=error_data,
+        error_type=error_type or PipelineError.UNSPECIFIED_DATA,
+        )
+    if 'user' in kwargs:
+        data.update(user=kwargs['user'])
+    if 'course_id' in kwargs:
+        data.update(course_id=str(kwargs['course_id']))
+    if 'site' in kwargs:
+        data.update(site=kwargs['site'])
+    PipelineError.objects.create(**data)
 
 
 def log_error(error_data, error_type=None, **kwargs):
-    logger.error(json.dumps(
+    kwargs.get('logger', default_logger).error(json.dumps(
         error_data,
         sort_keys=True,
         indent=1,
-        cls=DjangoJSONEncoder
-    ))
+        cls=DjangoJSONEncoder))
 
     if settings.log_pipeline_errors_to_db() or kwargs.get('log_pipeline_errors_to_db', False):
-        data = dict(
-            error_data=error_data,
-            error_type=error_type or PipelineError.UNSPECIFIED_DATA,
-            )
-        if 'user' in kwargs:
-            data.update(user=kwargs['user'])
-        if 'course_id' in kwargs:
-            data.update(course_id=str(kwargs['course_id']))
-        if 'site' in kwargs:
-            data.update(site=kwargs['site'])
-        PipelineError.objects.create(**data)
+        log_error_to_db(error_data, error_type, **kwargs)

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -16,9 +16,11 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from student.models import CourseEnrollment
 
 from figures.helpers import as_course_key, as_date
+from figures.models import PipelineError
 from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader
 from figures.pipeline.site_daily_metrics import SiteDailyMetricsLoader
 import figures.sites
+from figures.pipeline.logger import log_error
 
 logger = get_task_logger(__name__)
 
@@ -46,6 +48,8 @@ def populate_single_cdm(course_id, date_for=None, force_update=False):
     logger.info(msg)
 
     start_time = time.time()
+
+    # TODO: We
     cdm_obj, created = CourseDailyMetricsLoader(
         course_id).load(date_for=date_for, force_update=force_update)
     elapsed_time = time.time() - start_time
@@ -57,13 +61,15 @@ def populate_single_cdm(course_id, date_for=None, force_update=False):
 def populate_site_daily_metrics(site_id, **kwargs):
     '''Populate a SiteDailyMetrics record
     '''
-    logger.debug("populate_site_daily_metrics called")
+    logger.debug(
+        'populate_site_daily_metrics called for site_id={}'.format(site_id))
     SiteDailyMetricsLoader().load(
         site=Site.objects.get(id=site_id),
         date_for=kwargs.get('date_for', None),
         force_update=kwargs.get('force_update', False),
         )
-    logger.debug('done running populate_site_daily_metrics')
+    logger.debug(
+        'done running populate_site_daily_metrics for site_id={}"'.format(site_id))
 
 
 @shared_task
@@ -93,14 +99,31 @@ def populate_daily_metrics(date_for=None, force_update=False):
     logger.info('Starting task "figures.populate_daily_metrics" for date "{}"'.format(
         date_for))
 
-    # print('testing...')
-    # import pdb; pdb.set_trace()
     for site in Site.objects.all():
         for course in figures.sites.get_courses_for_site(site):
-            populate_single_cdm(
-                course_id=course.id,
-                date_for=date_for,
-                force_update=force_update)
+            try:
+                populate_single_cdm(
+                    course_id=course.id,
+                    date_for=date_for,
+                    force_update=force_update)
+            except Exception as e:
+                # Always capture CDM load exceptions to the Figures pipeline
+                # error table
+                error_data = dict(
+                    date_for=date_for,
+                    msg='figures.tasks.populate_daily_metrics failed',
+                    exception_class=e.__class__.__name__,
+                    )
+                if hasattr(e, 'message_dict'):
+                    error_data['message_dict'] = e.message_dict
+                log_error(
+                    error_data=error_data,
+                    error_type=PipelineError.COURSE_DATA,
+                    course_id=str(course.id),
+                    site=site,
+                    logger=logger,
+                    log_pipeline_errors_to_db=True,
+                    )
         populate_site_daily_metrics(
             site_id=site.id,
             date_for=date_for,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,99 @@
+"""
+
+"""
+
+import pytest
+
+from django.core.exceptions import ValidationError
+
+from figures.helpers import as_date
+from figures.models import (
+    CourseDailyMetrics,
+    PipelineError,
+    SiteDailyMetrics,
+    )
+import figures.tasks
+
+from tests.factories import (
+    CourseDailyMetricsFactory,
+    CourseOverviewFactory,
+    SiteFactory,
+    SiteDailyMetricsFactory,
+    )
+
+
+@pytest.fixture()
+def extracted_data():
+    return dict()
+
+
+def test_populate_single_cdm(transactional_db, monkeypatch):
+    assert CourseDailyMetrics.objects.count() == 0
+    date_for = '2019-01-02'
+    course_id = "course-v1:certs-appsembler+001+2019"
+    created = False
+
+    def mock_cdm_load(self, date_for, **kwargs):
+        return (CourseDailyMetricsFactory(date_for=date_for), created, )
+
+    monkeypatch.setattr(
+        figures.pipeline.course_daily_metrics.CourseDailyMetricsLoader,
+        'load', mock_cdm_load)
+    figures.tasks.populate_single_cdm(course_id, date_for)
+
+    assert CourseDailyMetrics.objects.count() == 1
+    assert as_date(CourseDailyMetrics.objects.first().date_for) == as_date(date_for)
+
+
+def test_populate_site_daily_metrics(transactional_db, monkeypatch):
+    assert SiteDailyMetrics.objects.count() == 0
+    date_for = '2019-01-02'
+    created = False
+    site = SiteFactory()
+
+    def mock_sdm_load(self, site, date_for, **kwargs):
+        return (SiteDailyMetricsFactory(site=site), created, )
+
+    monkeypatch.setattr(
+        figures.pipeline.site_daily_metrics.SiteDailyMetricsLoader,
+        'load', mock_sdm_load)
+    figures.tasks.populate_site_daily_metrics(site.id, date_for=date_for)
+
+    assert SiteDailyMetrics.objects.count() == 1
+
+
+def test_populate_daily_metrics_error(transactional_db, monkeypatch):
+    date_for = '2019-01-02'
+
+    def mock_get_courses(site):
+        return [CourseOverviewFactory()]
+
+    def mock_pop_single_cdm_fails(**kwargs):
+        # TODO: test with different exceptions
+        # At least one with and without `message_dict`
+        raise ValidationError(message={'message': 'expected failure'})
+
+    assert SiteDailyMetrics.objects.count() == 0
+    assert CourseDailyMetrics.objects.count() == 0
+    monkeypatch.setattr(
+        figures.sites, 'get_courses_for_site', mock_get_courses)
+    monkeypatch.setattr(
+        figures.tasks, 'populate_single_cdm', mock_pop_single_cdm_fails)
+
+    assert PipelineError.objects.count() == 0
+    with pytest.raises(Exception):
+        figures.tasks.populate_daily_metrics(date_for=date_for)
+    assert PipelineError.objects.count() == 1
+
+
+def test_populate_daily_metrics_multisite(transactional_db, monkeypatch):
+    # Stand up test data
+    date_for = '2019-01-02'
+    site_links = []
+    for domain in ['alpha.domain', 'bravo.domain']:
+        site_links.append(dict(
+            site=SiteFactory(domain=domain),
+            courses=[CourseOverviewFactory() for i in range(2)],
+        ))
+
+        figures.tasks.populate_daily_metrics(date_for=date_for)

--- a/tests/views/test_general_course_data_view.py
+++ b/tests/views/test_general_course_data_view.py
@@ -100,17 +100,11 @@ class TestGeneralCourseDataViewSet(BaseViewTest):
         super(TestGeneralCourseDataViewSet, self).setup(db)
         self.users = [make_user(**data) for data in USER_DATA]
         self.course_overviews = [make_course(**data) for data in COURSE_DATA]
-        #self.course_enrollments = [make_course_enrollments(user, self.course_overviews) for user in self.users]
-        #self.course_daily_metrics = [make_course_daily_metrics()]
         self.expected_result_keys = [
             'course_id', 'course_name', 'course_code','org', 'start_date',
             'end_date', 'self_paced', 'staff', 'metrics',
         ]
 
-    # @pytest.mark.parametrize('endpoint, filter', [
-    #     ('api/courses/general', {}),
-    #     ])
-    #def test_get_list(self, endpoint, filter):
     def test_get_list(self):
         '''Tests retrieving a list of users with abbreviated details
 
@@ -147,8 +141,6 @@ class TestGeneralCourseDataViewSet(BaseViewTest):
             `figures.serializers.UserIndexSerializer`
         '''
         course_id = self.course_overviews[0].id
-        # TODO: Add course id to path as well as query param
-        # request_path = self.request_path + '/' + str(course_id)
         request_path = self.request_path + '?pk=' + str(course_id)
         request = APIRequestFactory().get(request_path)
         force_authenticate(request, user=self.staff_user)

--- a/tests/views/test_general_course_data_view.py
+++ b/tests/views/test_general_course_data_view.py
@@ -147,9 +147,9 @@ class TestGeneralCourseDataViewSet(BaseViewTest):
             `figures.serializers.UserIndexSerializer`
         '''
         course_id = self.course_overviews[0].id
+        # TODO: Add course id to path as well as query param
         # request_path = self.request_path + '/' + str(course_id)
         request_path = self.request_path + '?pk=' + str(course_id)
-        # import pdb; pdb.set_trace()
         request = APIRequestFactory().get(request_path)
         force_authenticate(request, user=self.staff_user)
         view = self.view_class.as_view({'get': 'retrieve'})


### PR DESCRIPTION
This PR contains bug fixes, error handling and logging improvements

## Status:

Pipeline now works and runs in celery on Tahoe staging when kicked off from figure's django management command. However, it doesn't seem to be started automatically with celerybeat

It produces results.

There were two issues of note:

A) I needed to fix course's average progress which failed when trying to assign a 1.0. I fixed the max digits and added validation, which expected progress to be a decimal between 0 and 1 inclusive. I plan on revisiting how this metric is processed and stored in the mid-term if not sooner. So for sake of review, let's assume that the specification of average_process as a two decimal place floating point between 0.00 and 1.00 inclusive

B) The job would fail if a course raised an exception. So I improved error handling and logging to the tasks. We will now (for now) log all course metrics pipeline errors to the figures.models.PipelineError model).  

## What's in this PR (commit squash rollup) :

* Added field validation for CourseDailyMetrics.average_progress so that valid values must be between 0 and 1 with two decimal places max
* Increased CourseDailyMetrics.average_progress max digits from 2 to 3
* Improved test coverage
* Added test coverage for validating CDM data. The driver was a pipeline
failure during testing on Tahoe staging
* Improved and added test coverage for creating CDM records
* Reworked figures.pipeline logging so that celery logging could be used
* Improved daily metrics task error handling and logging

