### PR TITLE
fix learner counts

### DIFF
--- a/figures/filters.py
+++ b/figures/filters.py
@@ -12,6 +12,7 @@ from openedx.core.djangoapps.content.course_overviews.models import (
 )
 from student.models import CourseEnrollment
 
+from figures.pipeline.course_daily_metrics import get_enrolled_in_exclude_admins
 from figures.models import CourseDailyMetrics, SiteDailyMetrics
 
 
@@ -115,9 +116,7 @@ class UserFilterSet(django_filters.FilterSet):
         to be able to create a course key object from the string
         '''
         course_key = CourseKey.from_string(course_id_str.replace(' ', '+'))
-        # get course enrollments for the course
-        user_ids = CourseEnrollment.objects.filter(
-            course_id=course_key).values_list('user__id', flat=True).distinct()
+        user_ids = get_enrolled_in_exclude_admins(course_id=course_key)
         return queryset.filter(id__in=user_ids)
 
 

--- a/tests/pipeline/test_course_daily_metrics.py
+++ b/tests/pipeline/test_course_daily_metrics.py
@@ -110,7 +110,7 @@ class TestCourseDailyMetricsPipelineFunctions(object):
                     ),
             ) for i, days in enumerate(self.cert_days_to_complete)]
 
-    def test_get_num_enrolled_in_exclude_admins(self):
+    def test_get_enrolled_in_exclude_admins(self):
         """
 
         """
@@ -126,14 +126,14 @@ class TestCourseDailyMetricsPipelineFunctions(object):
             expected_count = ce_count - ce_non_students
             assert ce_count > 0 and ce_non_students > 0 and expected_count > 0, 'say something'
 
-            actual_count = pipeline_cdm.get_num_enrolled_in_exclude_admins(
+            learners = pipeline_cdm.get_enrolled_in_exclude_admins(
                 course_id=self.course_overview.id, date_for=self.today)
 
-            assert actual_count == expected_count
+            assert learners.count() == expected_count
 
-            actual_count = pipeline_cdm.get_num_enrolled_in_exclude_admins(
+            learners = pipeline_cdm.get_enrolled_in_exclude_admins(
                 course_id=str(self.course_overview.id), date_for=self.today)
-            assert actual_count == expected_count
+            assert learners.count() == expected_count
 
     def test_get_active_learner_ids_today(self):
         """


### PR DESCRIPTION
This PR replaces direct calls to `CourseEnrollment.objects.filter` and replaces with calls to `get_enrolled_in_exclude_admins` in figures.pipeline.course_daily_metrics.

Made the `date_for` parameter optional in `get_enrolled_in_exclude_admins`  to make the code cleaner. 

I pushed to staging and manually ran the pipeline succesfully