### PR TITLE
Backend fixes from BugFest

### DIFF
--- a/figures/filters.py
+++ b/figures/filters.py
@@ -53,7 +53,7 @@ class CourseEnrollmentFilter(django_filters.FilterSet):
 
     '''
 
-    course_id = django_filters.MethodFilter(action='filter_course_id')
+    course_id = django_filters.MethodFilter(action='course_id')
     is_active = django_filters.BooleanFilter(name='is_active',)
 
     def filter_course_id(self, queryset, course_id_str):
@@ -84,15 +84,17 @@ class UserFilterSet(django_filters.FilterSet):
     We're starting with a few fields and will add as we find we want/need them
 
     '''
-    is_active = django_filters.BooleanFilter(name='is_active',)
+    is_active = django_filters.BooleanFilter(name='is_active')
+    is_staff = django_filters.BooleanFilter(name='is_staff')
+    is_superuser = django_filters.BooleanFilter(name='is_superuser')
     username = django_filters.CharFilter(lookup_type='icontains')
     email = django_filters.CharFilter(lookup_type='icontains')
     country = django_filters.CharFilter(
         name='profile__country', lookup_type='iexact')
 
-    user_ids = django_filters.MethodFilter(action='filter_user_ids')
+    user_ids = django_filters.MethodFilter(action='user_ids')
     enrolled_in_course_id = django_filters.MethodFilter(
-        action='filter_enrolled_in_course_id')
+        action='enrolled_in_course_id')
 
     class Meta:
         model = get_user_model()

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -55,6 +55,8 @@ def get_enrolled_in_exclude_admins(course_id, date_for=None):
     Copied over from CourseEnrollmentManager.num_enrolled_in_exclude_admins method
     and modified to filter on date LT
 
+    If no date is provided then the date is not used as a filter
+
     """
     course_locator = as_course_key(course_id)
 
@@ -243,7 +245,7 @@ class CourseDailyMetricsExtractor(object):
         # set of calls defined in a ruleset instead of hardcoded here after
         # retrieving the core quersets
 
-        course_enrollments = get_course_enrollments(
+        course_enrollments = get_enrolled_in_exclude_admins(
             course_id, date_for,)
 
         data = dict(date_for=date_for, course_id=course_id)
@@ -252,8 +254,7 @@ class CourseDailyMetricsExtractor(object):
         # After we get this working, we can then define them declaratively
         # we can do a lambda for course_enrollments to get the count
 
-        data['enrollment_count'] = get_enrolled_in_exclude_admins(
-            course_id, date_for).count()
+        data['enrollment_count'] = course_enrollments.count()
         active_learner_ids_today = get_active_learner_ids_today(
             course_id, date_for,)
         if active_learner_ids_today:

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -35,19 +35,7 @@ import figures.sites
 logger = logging.getLogger(__name__)
 
 
-#
 # Extraction helper methods
-#
-
-
-def get_course_enrollments(course_id, date_for):
-    """Convenience method to get a filterd queryset of CourseEnrollment objects
-
-    """
-    return CourseEnrollment.objects.filter(
-        course_id=as_course_key(course_id),
-        created__lt=as_datetime(next_day(date_for)),
-    )
 
 
 def get_enrolled_in_exclude_admins(course_id, date_for=None):

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -221,8 +221,8 @@ class GeneralCourseDataSerializer(serializers.Serializer):
                     "average_completion_time": "some_time_in_standardised_format",
                     "users_completed": 493, // total number of users that have
                                             // completed the course since the
-                                     tests/views/base.py       // course was created
-                }tests/views/base.py
+                                            // course was created
+                }
             },
             ...
         ]

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -221,8 +221,8 @@ class GeneralCourseDataSerializer(serializers.Serializer):
                     "average_completion_time": "some_time_in_standardised_format",
                     "users_completed": 493, // total number of users that have
                                             // completed the course since the
-                                            // course was created
-                }
+                                     tests/views/base.py       // course was created
+                }tests/views/base.py
             },
             ...
         ]
@@ -237,9 +237,9 @@ class GeneralCourseDataSerializer(serializers.Serializer):
     org = serializers.CharField(
         source='display_org_with_default', read_only=True)
     start_date = serializers.DateTimeField(
-        source='enrollment_start', read_only=True, default=None)
+        source='start', read_only=True, default=None)
     end_date = serializers.DateTimeField(
-        source='enrollment_end', read_only=True, default=None)
+        source='end', read_only=True, default=None)
     self_paced = serializers.BooleanField(read_only=True)
 
     staff = serializers.SerializerMethodField()
@@ -327,9 +327,9 @@ class CourseDetailsSerializer(serializers.ModelSerializer):
     org = serializers.CharField(
         source='display_org_with_default', read_only=True)
     start_date = serializers.DateTimeField(
-        source='enrollment_start', read_only=True, default=None)
+        source='start', read_only=True, default=None)
     end_date = serializers.DateTimeField(
-        source='enrollment_end', read_only=True, default=None)
+        source='end', read_only=True, default=None)
     self_paced = serializers.BooleanField(read_only=True)
 
     staff = serializers.SerializerMethodField()

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -715,9 +715,12 @@ class LearnerDetailsSerializer(serializers.ModelSerializer):
         """
         This method is a hack until I figure out customizing DRF fields and/or
         related serializers to explicitly link models not linked via FK
+
         """
-        return LearnerCourseDetailsSerializer(
-            CourseEnrollment.objects.filter(user=user), many=True).data
+
+        course_enrollments = figures.sites.get_course_enrollments_for_site(
+            self.context.get('site')).filter(user=user)
+        return LearnerCourseDetailsSerializer(course_enrollments, many=True).data
 
     def get_profile_image(self, user):
         if hasattr(user, 'profile'):

--- a/figures/views.py
+++ b/figures/views.py
@@ -272,21 +272,19 @@ class CourseDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
 
     '''
     model = CourseOverview
-    # queryset = CourseOverview.objects.all()
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = CourseDetailsSerializer
     filter_backends = (DjangoFilterBackend, )
     filter_class = CourseOverviewFilter
 
     def get_queryset(self):
-        print('CourseDetailsViewSet.get_queryset called')
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
         queryset = figures.sites.get_courses_for_site(site)
         return queryset
 
     def retrieve(self, request, *args, **kwargs):
-        print('CourseDetailsSerializer.retrieve called')
         # NOTE: Duplicating code in GeneralCourseDataViewSet. Candidate to dry up
+        # Make it a decorator
         course_id_str = kwargs.get('pk', '')
         course_key = CourseKey.from_string(course_id_str.replace(' ', '+'))
         site = django.contrib.sites.shortcuts.get_current_site(request)
@@ -330,8 +328,12 @@ class LearnerDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     filter_class = UserFilterSet
 
     def get_queryset(self):
-        '''
-        '''
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
         queryset = figures.sites.get_users_for_site(site)
         return queryset
+
+    def retrieve(self, request, pk, *args, **kwargs):
+        site = django.contrib.sites.shortcuts.get_current_site(request)
+        user = get_object_or_404(self.get_queryset(), pk=pk)
+        return Response(LearnerDetailsSerializer(
+            instance=user, context=dict(site=site)).data)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -168,11 +168,15 @@ class CourseOverviewFactory(DjangoModelFactory):
     number = '2161'
     display_org_with_default = factory.LazyAttribute(lambda o: o.org)
     created = fuzzy.FuzzyDateTime(datetime.datetime(
-        2018,02,01, tzinfo=factory.compat.UTC))
+        2018, 2, 1, tzinfo=factory.compat.UTC))
     enrollment_start = fuzzy.FuzzyDateTime(datetime.datetime(
-        2018,02,02, tzinfo=factory.compat.UTC))
+        2018, 3, 1, tzinfo=factory.compat.UTC))
     enrollment_end = fuzzy.FuzzyDateTime(datetime.datetime(
-        2018,05,05, tzinfo=factory.compat.UTC))
+        2018, 3, 15, tzinfo=factory.compat.UTC))
+    start = fuzzy.FuzzyDateTime(datetime.datetime(
+        2018, 4, 1, tzinfo=factory.compat.UTC))
+    end = fuzzy.FuzzyDateTime(datetime.datetime(
+        2018, 6, 1, tzinfo=factory.compat.UTC))
     self_paced = False
 
 

--- a/tests/mocks/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/tests/mocks/openedx/core/djangoapps/content/course_overviews/models.py
@@ -52,9 +52,12 @@ class CourseOverview(models.Model):
     display_org_with_default = models.TextField()
     number = models.TextField()
     created = models.DateTimeField(null=True) # from TimeStampedModel
+    start = models.DateTimeField(null=True)
+    end = models.DateTimeField(null=True)
     enrollment_start = models.DateTimeField(null=True)
     enrollment_end = models.DateTimeField(null=True)
     self_paced = models.BooleanField(default=False)
+
     @property
     def display_name_with_default_escaped(self):
         return self.display_name

--- a/tests/pipeline/test_course_daily_metrics.py
+++ b/tests/pipeline/test_course_daily_metrics.py
@@ -51,7 +51,7 @@ class TestGetCourseEnrollments(object):
             course_id=course_id,
             created__lt=as_datetime(
                 next_day(self.today))).values_list('id', flat=True)
-        results_ce = pipeline_cdm.get_course_enrollments(
+        results_ce = pipeline_cdm.get_enrolled_in_exclude_admins(
             course_id=course_id,
             date_for=self.today).values_list('id', flat=True)
         assert set(results_ce) == set(expected_ce)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -88,8 +88,12 @@ class CourseEnrollmentFilterTest(TestCase):
         expected_results = CourseEnrollment.objects.filter(course_id=course_id)
         assert expected_results.count() != len(self.course_enrollments)
         f = CourseEnrollmentFilter(queryset=expected_results)
+
+        res = CourseEnrollmentFilter().filter_course_id(
+            queryset=CourseEnrollment.objects.all(),
+            course_id_str=str(course_id))
         self.assertQuerysetEqual(
-            f.qs,
+            res,
             [o.id for o in expected_results],
             lambda o: o.id,
             ordered=False)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -128,8 +128,8 @@ class TestCourseDetailsSerializer(object):
         assert data['course_name'] == self.course_overview.display_name
         assert data['course_code'] == self.course_overview.number
         assert data['org'] == self.course_overview.org
-        assert parse(data['start_date']) == self.course_overview.enrollment_start
-        assert parse(data['end_date']) == self.course_overview.enrollment_end
+        assert parse(data['start_date']) == self.course_overview.start
+        assert parse(data['end_date']) == self.course_overview.end
         assert data['self_paced'] == self.course_overview.self_paced
 
     def test_get_staff_with_no_course(self):
@@ -319,8 +319,8 @@ class TestGeneralCourseDataSerializer(object):
         assert data['course_name'] == self.course_overview.display_name
         assert data['course_code'] == self.course_overview.number
         assert data['org'] == self.course_overview.org
-        assert parse(data['start_date']) == self.course_overview.enrollment_start
-        assert parse(data['end_date']) == self.course_overview.enrollment_end
+        assert parse(data['start_date']) == self.course_overview.start
+        assert parse(data['end_date']) == self.course_overview.end
         assert data['self_paced'] == self.course_overview.self_paced
 
     def test_get_metrics_with_cdm_records(self):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -397,6 +397,7 @@ class TestLearnerCourseDetailsSerializer(object):
         #     'profile__country': 'CA',
         # }
         #self.user = UserFactory(**self.user_attributes)
+        self.site = Site.objects.first()
         self.certificate_date = datetime.datetime(2018, 4, 1, tzinfo=utc)
         self.course_enrollment = CourseEnrollmentFactory(
             )
@@ -426,13 +427,15 @@ class TestLearnerDetailsSerializer(object):
 
     @pytest.fixture(autouse=True)
     def setup(self, db):
+        self.site = Site.objects.first()
         self.user_attributes = {
             'username': 'alpha_one',
             'profile__name': 'Alpha One',
             'profile__country': 'CA',
         }
         self.user = UserFactory(**self.user_attributes)
-        self.serializer = LearnerDetailsSerializer(instance=self.user)
+        self.serializer = LearnerDetailsSerializer(
+            instance=self.user, context=dict(site=self.site))
 
     def test_has_fields(self):
         '''Tests that the serialized UserIndex data has specific keys and values
@@ -454,6 +457,13 @@ class TestLearnerDetailsSerializer(object):
         # This is to make sure that the serializer retrieves the correct nested
         # model (UserProfile) data
         assert data['name'] == 'Alpha One'
+
+    @pytest.mark.skip(reason='Not implemented')
+    def test_excludes_other_sites(self):
+        """
+        Need to make sure that only courses for the requesting site are returned
+        """
+        pass
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Cross-site courses

Now only courses for the current site should show in the course list on the user page.

This one is a bit interesting. The learner details serializer is required to provide a list of the courses for which the learner is enrolled. Previously it was not filtering courses on the current site. To make the learner details serializer course list filter on site, the site object or a site unique identifier needs to be available to the serializer's `get_courses` method. One option I looked into was adding `site` to the serializer constructors, but it felt like a hack, so I investigated and learned about the `context` 
argument: https://www.django-rest-framework.org/api-guide/serializers/#including-extra-context.

`LearnerDetailsViewSet` now has a `retrieve` method that passes the current site as the context to the serializer.

## Course start dates

Should no longer start at "Thu, 01 Jan 1970 00:00:00 GMT"

Figures was using `CourseOverview` `enrollment_start` and `enrollment_end` for the course start and end dates. Now `CourseOvervew` `start` and `end` fields are used.

## Learner List

Now learners list should not be empty if the course has enrolled learners.

The problem was that the `action` parameter in the UserFilterSet method filter field `enrolled_in_course_id`. It had the `filter_` prefix.

The front end calls `/figures/api/learners/details/?enrolled_in_course_id` but the filter was expecting `/figures/api/learners/details/?filter_enrolled_in_course_id`.

Also fixed are the other filters that used the `filter_` prefix in the action parameter.

## Testing

Updated tests for the code changes and added a test stub for excluding other sites. I created a card to follow up with this
