### PR TITLE
set up TravisCI automated PyPI releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,13 @@ script:
 
 env:
   - TOXENV=py27-openedx_ginkgo
+
+deploy:
+  provider: pypi
+  user: "appsembler"
+  password:
+    secure: "pWuvP9KMp1CZsxftXFDfJlL2FzhrFWrfyVndHwo15M+zXOCLx73mFfClekkg3clRyMNV4Wit6536kk3BPBqvgVcRb+o0gj48i0x2/9Py99RNxeJXUgSDCs9hUkNoiGDPEIRsXCiaAx+JLxuoeyHUxCA8Heh6E/7/83BJLL47FgzOdW9hIihB/wTEHjp7eVZNItoLoA58yRA8DZNy2sFE57cDp4bubL3KNTqFlZIY1b6W6CErfCh1fOc2N/c9/0mV2mo0K2rJLw+0sw/qqD3git1wSfu14vbqVrUY5Yp9aGALdIeWCM7Ll2sqPpUd0zVHqNWRubrTtYIcb8LsyNDlRVvvy6CyDXj/yeudOWUrg3XshtOO90k7yxnA5eFm1IFp4FpszZfIyzmwoXqyUT8OSQPnUanieOH28Enxq5VzIOOKJn3qLX6ViWnBssK162cUMxRbIBeImiWhm9E7tWo5nPaJ9W/n+GZwzU0acOa0oYv7k+K+2i26KdqJ056G5ToN1u8JJ0V21TnkGa9IGki9A6F0zmVXdNoTHOMkhqztNBiTIjejrZZmvP+08uY7XnJDMNUm+IO/WjlN1eaHE98jMj/zMaa35yEGEujs5FKiwG7elGK13bL57Cia2qBzsYw4cxq6O5M8XxTEmNF6RloZn9PXg8xFRaD6PNTxUs9UIfc="
+  on:
+    tags: true
+  distributions: "sdist bdist_wheel"
+  skip_existing: true


### PR DESCRIPTION
Travis will build packages and upload them to PyPI when tags are pushed.

Documentation on the recommended release process is in our wiki: https://appsembler-infrastructure.appspot.com/post/runbook-new-pypi-release/