### PR TITLE
add flake8 and pylint configs to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
 
 env:
   - TOXENV=py27-openedx_ginkgo
+  - TOXENV=flake8
 
 deploy:
   provider: pypi

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,11 @@
 [tox]
 # currently disabled envs prior to hawthorn, as the test suite is now hardcoded
 # for hawthorn. Will fix prior to hawthorn upgrade PR.
-envlist = 
+envlist =
 	py27-openedx_ginkgo
 	py27-openedx_hawthorn
 	py27-appsembler_hawthorn
+	flake8
 
 [pytest]
 
@@ -19,8 +20,21 @@ deps =
 	openedx_hawthorn: -r{toxinidir}/devsite/requirements/hawthorn.txt
 	appsembler_ficus: -r{toxinidir}/devsite/requirements/ficus_appsembler.txt
 	appsembler_hawthorn: -r{toxinidir}/devsite/requirements/hawthorn_appsembler.txt
-	
+
 setenv =
 	DJANGO_SETTINGS_MODULE = devsite.test_settings
 	PYTHONPATH = {toxinidir}
 commands = pytest {posargs}
+
+[testenv:lint]
+deps =
+	pylint==1.9.4 # last version to support python 2
+	pylint-django==0.11.1 # last version to support python 2
+commands =
+	pylint --load-plugins pylint_django ./figures
+
+[testenv:flake8]
+deps =
+	flake8==3.7.7
+commands =
+	flake8 figures devsite


### PR DESCRIPTION
Enable flake8 automatically on Travis as well (pylint isn't passing yet, so we don't enable that. I just included it because there was a Makefile target to run it so presumably it's something we're interested in?)