### PR TITLE
Doc and labeling update for 0.3.0 Pre-release 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,21 +12,25 @@ Reporting and data retrieval app for `Open edX <https://open.edx.org/>`__.
 Notice and Development Status
 -----------------------------
 
-12 APR 2019 - Hawthorn Pre-release
-==================================
+05 Aug 2019 - Hawthorn Pre-release 2
+====================================
 
-**Hawthorn 0.3.0 pre-release is now available!**
+**Hawthorn 0.3.0 pre-release 2 is available**
 
 * Figures 0.3.0 supports Hawthorn
 * Uses the new plugin capability introduced in Open edX Hawthorn
 * Includes a standalone development mode. See the `developer quickstart guide <./DEVELOPER-QUICKSTART.md/>`__
 
 
-Run the following to install Figures 0.3.0 prerelease for evaluation:
+Pre-release 2 addresses Hawthorn upgrade compatibility issues not identified in Pre-release 1
+
+
+
+Run the following to install Figures 0.3.0 prerelease 2 for evaluation:
 
 ::
 
-	pip install https://github.com/appsembler/figures/archive/0.3.0-prerelease.zip
+	pip install https://github.com/appsembler/figures/archive/0.3.0-prerelease2.zip
 
 For installing for development, such as with docker devstack:
 

--- a/docs/readme-pypi.rst
+++ b/docs/readme-pypi.rst
@@ -2,10 +2,19 @@ Figures is a Django reusable app for `Open edX <https://open.edx.org/>`__ to pro
 
 Please see the project `README <https://github.com/appsembler/figures/blob/master/README.rst>`__ on Github for more information.
 
-------------
-Requirements
-------------
+
+## Requirements
+
+
+### Figures 0.3.x
+
+
+* Python (2.7)
+* Django (1.11)
+* Open edX Hawthorn
+
+### Figures 0.2.x
 
 * Python (2.7)
 * Django (1.8)
-* Open edX (Ginkgo)
+* Open edX Ficus or Ginkgo

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='Figures',
-    version='0.3.0prerelease',
+    version='0.3.0prerelease2',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',


### PR DESCRIPTION
Minor documentation updates and updated setup.py version from `0.3.0prerelease` to `0.3.0prerelease2`

After this PR is accepted, I'll do a develop -> master PR and once that is accepted, then cut the new prerelease2 tag