### PR TITLE
(WIP) Initial Figures serializers for downloadable (CSV) reporting

### DIFF
--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -789,6 +789,13 @@ class LegacyEnrollmentReportSerializer(serializers.ModelSerializer):
 
     def get_final_score(self, obj):
         """
-        TODO: Add data per builder field "grade_data.percent" in Appsembler reporting
+        TODO: Add data per builder field "grade_data.percent" from Appsembler Reporting
+        Steps:
+        1. Submit serializers for PR
+        2. Update pipeline and make sure final score is stored in Figures models.
+           Add a field in the LearnerCourseGradeMetrics for our first iteration.
+           Post this PR
+        3. Update the serializer to retrieve the final score from Figures models.
+           Post this PR
         """
         return None

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -731,3 +731,31 @@ class LearnerDetailsSerializer(serializers.ModelSerializer):
                             user.profile, user, None)
         else:
             return None
+
+
+# CSV report serializers
+
+
+class UserReportSerializer(serializers.ModelSerializer):
+    user_id = serializers.IntegerField(source='id')
+    full_name = serializers.CharField(source='profile.name', default=None)
+    date_registered = serializers.DateTimeField(source='date_joined')
+    email_domain = serializers.SerializerMethodField()
+    country = SerializeableCountryField(
+        source='profile.country',
+        required=False, allow_blank=True)
+
+    class Meta:
+        model = get_user_model()
+        fields = [
+            'user_id', 'username', 'full_name', 'email', 'email_domain',
+            'country', 'is_active', 'date_registered', 'last_login',
+        ]
+        read_only_fields = fields
+
+    def get_email_domain(self, obj):
+        try:
+            email_domain = obj.email.split('@')[1]
+        except Exception:
+            email_domain = ''
+        return email_domain

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -759,3 +759,36 @@ class UserReportSerializer(serializers.ModelSerializer):
         except Exception:
             email_domain = ''
         return email_domain
+
+
+class LegacyEnrollmentReportSerializer(serializers.ModelSerializer):
+
+    enrollment_id = serializers.IntegerField(source='id')
+    course_id = serializers.CharField(source='course.id')
+    course_name = serializers.CharField(source='course.display_name')
+    user_id = serializers.IntegerField(source='user.id')
+    username = serializers.CharField(source='user.username')
+    full_name = serializers.CharField(source='user.profile.name')
+    country = SerializeableCountryField(source='user.profile.country',
+                                        required=False, allow_blank=True)
+    email = serializers.CharField(source='user.email')
+    is_active = serializers.BooleanField(source='user.is_active')
+    last_login = serializers.DateTimeField(source='user.last_login')
+    date_registered = serializers.DateTimeField(source='user.date_joined')
+    course_enrollment_date = serializers.DateTimeField(source='created')
+    final_score = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CourseEnrollment
+        fields = [
+            'course_id', 'course_name', 'enrollment_id', 'user_id', 'username',
+            'full_name', 'country', 'email', 'is_active', 'last_login',
+            'date_registered', 'course_enrollment_date', 'final_score'
+        ]
+        read_only_fields = fields
+
+    def get_final_score(self, obj):
+        """
+        TODO: Add data per builder field "grade_data.percent" in Appsembler reporting
+        """
+        return None

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -519,7 +519,7 @@ class TestUserReportSerializer(object):
         (datetime.datetime(2018, 2, 2, tzinfo=pytz.UTC), None),
         (datetime.datetime(2018, 2, 2, tzinfo=pytz.UTC), 'CA')
         ])
-    def test_one(self, last_login, country):
+    def test_get_one(self, last_login, country):
         """
         Performs basic testing on the serializer for a single user
         """

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -28,6 +28,7 @@ from figures.serializers import (
     SiteDailyMetricsSerializer,
     UserIndexSerializer,
     UserReportSerializer,
+    LegacyEnrollmentReportSerializer,
 )
 
 from tests.factories import (
@@ -540,3 +541,26 @@ class TestUserReportSerializer(object):
         serializer = UserReportSerializer(users, many=True)
         data = serializer.data
         assert len(data) == len(users)
+
+
+@pytest.mark.django_db
+class TestLegacyEnrollmentReportSerializer(object):
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.expected_fields = [
+            'course_id', 'course_name', 'enrollment_id', 'user_id', 'username',
+            'full_name', 'country', 'email', 'is_active', 'last_login',
+            'date_registered', 'course_enrollment_date', 'final_score'
+        ]
+
+    def test_get_one(self):
+        enrollment = CourseEnrollmentFactory()
+        serializer = LegacyEnrollmentReportSerializer(instance=enrollment)
+        data = serializer.data
+        assert set(data.keys()) == set(self.expected_fields)
+
+    def test_get_many(self):
+        enrollments = [CourseEnrollmentFactory() for i in xrange(0, 4)]
+        serializer = LegacyEnrollmentReportSerializer(enrollments, many=True)
+        data = serializer.data
+        assert len(data) == len(enrollments)


### PR DESCRIPTION
Relabeled as a "WIP" as this is not immediately needed for DL reports

_note: renamed the branch from `dl-reports` to `dl-rpt-serializers`_

We're trying out doing the downloadable reports in a set of three or four phased PRs.

This PR: "Part A" - Implement report serializers for the user report and the enrollment report. Skip fields that require additional pipeline work

"Part B" - Implement view to retrieve CSV formatted data using the serializers in "Part A" We want to test request timing

"Part C" - Celery task report generation - Job to generate report and store for later retrieval

"Part D" - Retrieval of asynchronously generated reports

"Part E+" Follow on work as needed. Fix bugs, improve workflow, etc