### PR TITLE
Test fixes - removed local hardcoded date string from view tests

### DIFF
--- a/tests/views/test_course_daily_metrics_view.py
+++ b/tests/views/test_course_daily_metrics_view.py
@@ -88,8 +88,6 @@ class TestCourseDailyMetricsView(BaseViewTest):
 
         TODO: Add more date ranges
         '''
-        first_day='2018-02-01'
-        last_day='2018-02-28'
         endpoint = '{}?date_0={}&date_1={}'.format(
             self.request_path, first_day, last_day)
 

--- a/tests/views/test_site_daily_metrics_view.py
+++ b/tests/views/test_site_daily_metrics_view.py
@@ -76,8 +76,6 @@ class TestSiteDailyMetricsView(BaseViewTest):
 
         TODO: Add more date ranges
         '''
-        first_day='2018-02-01'
-        last_day='2018-02-28'
         endpoint = '{}?date_0={}&date_1={}'.format(
             self.request_path, first_day, last_day)
 


### PR DESCRIPTION
Removed hard-coded local scope variables because they overwrote the parametrize declared test variables