### PR TITLE
Celery imports test fix

### DIFF
--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -43,7 +43,7 @@ def as_course_key(course_id):
     '''
     if isinstance(course_id, CourseKey):
         return course_id
-    elif isinstance(course_id, basestring):
+    elif isinstance(course_id, basestring):  # noqa: F821
         return CourseKey.from_string(course_id)
     else:
         raise TypeError('Unable to convert course id with type "{}"'.format(
@@ -65,7 +65,7 @@ def as_datetime(val):
             day=val.day,
             ).replace(tzinfo=utc)
 
-    elif isinstance(val, basestring):
+    elif isinstance(val, basestring):  # noqa: F821
         return dateutil_parse(val).replace(tzinfo=utc)
     else:
         raise TypeError(
@@ -84,7 +84,7 @@ def as_date(val):
         return val.date()
     elif isinstance(val, datetime.date):
         return val
-    elif isinstance(val, basestring):
+    elif isinstance(val, basestring):  # noqa: F821
         return dateutil_parse(val).date()
     else:
         raise TypeError(

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -169,7 +169,7 @@ def experimental_populate_daily_metrics(date_for=None, force_update=False):
     courses = CourseOverview.objects.all()
     cdm_tasks = [
         populate_single_cdm.s(
-            course_id=unicode(course.id),
+            course_id=unicode(course.id),  # noqa: F821
             date_for=date_for,
             force_update=force_update) for course in courses if include_course(course)
     ]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -74,7 +74,8 @@ class TestUpdateSettings(object):
             FEATURES={},
             ENV_TOKENS={
                 'FIGURES': figures_env_tokens,
-            }
+            },
+            CELERY_IMPORTS=[],
         )
         plugin_settings(settings)
 


### PR DESCRIPTION
Tests on the previous PR were failing. `CELERY_IMPORTS` needed to be added to the settings mock.

Flake8 was also failing for me. `unicode` and `basename` aren't defined in python3 and recent versions of flake8 try to help by pointing that out. For now, just `noqa`'d them, but those will need to be addressed at some point for figures to support python3.