### PR TITLE
Devsite: Added more courses to test front end courses list

### DIFF
--- a/DEVELOPER-QUICKSTART.md
+++ b/DEVELOPER-QUICKSTART.md
@@ -40,7 +40,10 @@ now we'll run [pytest](https://docs.pytest.org/) to make sure that the tests pas
 pytest
 ```
 
-## 4. Set up Figures standalone server
+## 4. Build front end assets
+
+
+## 5. Set up Figures standalone server
 
 Navigate to your Figures workspace (you will be here if you just completed the previous step)
 
@@ -65,7 +68,7 @@ Last step before starting the dev server is to fill our environment with some mo
 
 The `seed_data` command populates the dev server with mock data then builds metrics on the mock data, backfilling historical data (experimental feature)
 
-## 5. Starting Figures devsite
+## 6. Starting Figures devsite
 
 Navigate to your Figures workspace (you will be here if you just completed the previous step)
 
@@ -85,7 +88,7 @@ Enter the credentials you used to create the superuser in step 4.
 
 Now you can click on the Figures link on the page to go to the Figures dashboard.
 
-## 6. Navigating around Figures
+## 7. Navigating around Figures
 
 _Section incomplete_
 
@@ -95,7 +98,7 @@ Pages of interest:
 * http://127.0.0.1:8000/figures/api/
 * http://127.0.0.1:8000/admin/figures/
 
-## 7. Running the pipeline manually
+## 8. Running the pipeline manually
 
 The Figures pipeline will automatically run once a day in a running Open edX Hawthorn instance. The default time os 02:00 UTC and can be configured in the server vars (`lms.env.json`).
 
@@ -109,28 +112,19 @@ Make sure you have your development virtualenv running. Then navigate to the `de
 
 This will run the pipeline immediately instead of being queued to celery.
 
-## 8. Building the front end
+## 9. Building the front end assets
 
-_Section incomplete_
+You will need yarn installed.
 
-The frontend assets come pre-built for the Hawthorn prerelease. If you modify the front end code then you will either need to re-compile the frontend assets or run the Webpack development server. This section describes how to build the front end, which is also needed to deploy your modifications in a production environment.
+Go to the `frontend` directory and run `yarn`. This will install dependencies
 
-You will need NPM installed to build the front end assets. 
+Run `yarn build` to compile the front end assets.
 
-From your project root, run the following:
 
-```
-cd frontend
-npm install
-npm run build
-```
-
-_TODO: provide example of adding custom layout settings_
-
-## 7. Running the frontend Webpack server
+## 10. Running the frontend Webpack server
 
 _TODO: Add this section_
 
-## 8. Installing Figures on Hawthorn Docker Devstack
+## 11. Installing Figures on Hawthorn Docker Devstack
 
 _TODO: Add this section_

--- a/devsite/devsite/cans/course_overviews.py
+++ b/devsite/devsite/cans/course_overviews.py
@@ -1,4 +1,6 @@
 """
+
+This module provides canned courses to test specific criteria
 TODO:
 * Add self-paced flag
 """
@@ -14,6 +16,7 @@ COURSE_OVERVIEW_DATA = [
         enrollment_start='2018-08-01',
         enrollment_end='2018-12-31',
         ),
+    # The following provide two identical courses with different runs
     dict(
         id='course-v1:StarFleetAcademy+SFA02+2161',
         display_name='Intro to Xenology',
@@ -23,5 +26,15 @@ COURSE_OVERVIEW_DATA = [
         created='2018-09-01',
         enrollment_start='2018-10-05',
         enrollment_end='2019-02-02',
+        ),
+    dict(
+        id='course-v1:StarFleetAcademy+SFA02+2162',
+        display_name='Intro to Xenology',
+        org='StarFleetAcademy',
+        display_org_with_default='StarFleetAcademy',
+        number='SFA03',
+        created='2019-09-01',
+        enrollment_start='2019-10-05',
+        enrollment_end='2020-02-02',
         ),
 ]

--- a/devsite/devsite/seed.py
+++ b/devsite/devsite/seed.py
@@ -52,7 +52,7 @@ def days_back_list(days_back):
 
 def generate_course_overview(index, **vals):
 
-    org=vals.get('org', 'ORG-{}'.format(index))
+    org = vals.get('org', 'ORG-{}'.format(index))
 
     rec = dict(
         # id='course-v1:StarFleetAcademy+SFA01+2161',
@@ -67,6 +67,7 @@ def generate_course_overview(index, **vals):
     run = '000{}'.format(index)
     rec['id'] = 'course-v1:{0}+{1}+{2}'.format(org, rec['number'], run)
     return rec
+
 
 def seed_course_overviews(data=None):
 

--- a/devsite/devsite/seed.py
+++ b/devsite/devsite/seed.py
@@ -50,10 +50,31 @@ def days_back_list(days_back):
     return [day for day in rrule(DAILY, dtstart=start_date, until=end_date)]
 
 
+def generate_course_overview(index, **vals):
+
+    org=vals.get('org', 'ORG-{}'.format(index))
+
+    rec = dict(
+        # id='course-v1:StarFleetAcademy+SFA01+2161',
+        display_name=vals.get('display_name', FAKE.sentence(nb_words=2)),
+        org=org,
+        display_org_with_default=org,
+        number=vals.get('number', 'NUM-{}'.format(index)),
+        created='2018-07-01',
+        enrollment_start='2018-08-01',
+        enrollment_end='2018-12-31',
+        )
+    run = '000{}'.format(index)
+    rec['id'] = 'course-v1:{0}+{1}+{2}'.format(org, rec['number'], run)
+    return rec
+
 def seed_course_overviews(data=None):
 
     if not data:
         data = cans.COURSE_OVERVIEW_DATA
+        # append with randomly generated course overviews to test pagination
+        new_courses = [generate_course_overview(i, org='FOO') for i in xrange(20)]
+        data += new_courses
 
     for rec in data:
         course_id = rec['id']

--- a/devsite/requirements/hawthorn_appsembler.txt
+++ b/devsite/requirements/hawthorn_appsembler.txt
@@ -12,7 +12,7 @@
 celery==3.1.25
 
 # Faker is used to seed mock data in devsite
-Faker==1.0.4
+Faker==2.0.3
 python-dateutil==2.7.3
 path.py==8.2.1
 


### PR DESCRIPTION
* Added more courses to the devsite `seed_data` Django management command in order to test the front end (Since we don't have automated tests). This also provides a *foundation* for more procedurally generated content  
* Updated Faker to most recent release
* Minor updates to the developer quickstart guide

