### PR TITLE
API Hack: allow up to 1000 general course data records to be returned

### DIFF
--- a/figures/pagination.py
+++ b/figures/pagination.py
@@ -9,3 +9,9 @@ class FiguresLimitOffsetPagination(LimitOffsetPagination):
     '''Custom Figures paginator to make the number of records returned consistent
     '''
     default_limit = 20
+
+
+class FiguresKiloPagination(LimitOffsetPagination):
+    '''Custom Figures paginator to make the number of records returned consistent
+    '''
+    default_limit = 1000

--- a/figures/views.py
+++ b/figures/views.py
@@ -52,7 +52,10 @@ from figures.serializers import (
     GeneralUserDataSerializer
 )
 from figures import metrics
-from figures.pagination import FiguresLimitOffsetPagination
+from figures.pagination import (
+    FiguresLimitOffsetPagination,
+    FiguresKiloPagination,
+)
 import figures.permissions
 import figures.helpers
 import figures.sites

--- a/figures/views.py
+++ b/figures/views.py
@@ -263,7 +263,10 @@ class GeneralCourseDataViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
 
     '''
     model = CourseOverview
-    pagination_class = FiguresLimitOffsetPagination
+
+    # The "kilo paginator"  is a tempoarary hack to return all course to not
+    # have to change the front end until Figures "Level 2"
+    pagination_class = FiguresKiloPagination
     serializer_class = GeneralCourseDataSerializer
 
     def get_queryset(self):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,9 +1,14 @@
-from figures.pagination import FiguresLimitOffsetPagination
+from figures.pagination import (
+    FiguresLimitOffsetPagination,
+    FiguresKiloPagination,
+)
 
 
 class TestFiguresLimitOffsetPagination(object):
-    '''
-
-    '''
     def test_default_pagination_limit(self):
         assert FiguresLimitOffsetPagination.default_limit == 20
+
+
+class TestFigureKiloPagination(object):
+    def test_default_pagination_limit(self):
+        assert FiguresKiloPagination.default_limit == 1000


### PR DESCRIPTION
We are doing this so that we don't have to implement pagination for the
front end site page. This is a tempoarary hack that we need to fix as we
revisit the API

@OmarIthawi This was an agreed upon hack between Matej and John. We know we need to revisit the API design