### PR TITLE
Test environment cleanup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,3 @@ omit =
     setup.py
     tests/*
     mocks/*
-

--- a/devsite/requirements/hawthorn_appsembler.txt
+++ b/devsite/requirements/hawthorn_appsembler.txt
@@ -59,15 +59,15 @@ git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4
 ## Test dependencies
 ##
 
-coverage==4.5.1
+coverage==4.5.4
 factory-boy==2.5.1
-flake8==3.7.7
-pylint==1.8.2
-pylint-django==0.9.1
+flake8==3.7.9
+pylint==1.9.5
+pylint-django==0.11.1
 pytest==3.1.3
 pytest-django==3.1.2
 pytest-mock==1.7.1
 pytest-pythonpath==0.7.2
 pytest-cov==2.6.0
-tox==3.7.0
+tox==3.14.2
 freezegun==0.3.12

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,22 +1,23 @@
-'''Helper methods for Figures testing
-'''
+"""Helper methods for Figures testing
+"""
 
 from dateutil.rrule import rrule, DAILY
 from packaging import version
 
-import organizations
-
-import figures.sites
+from organizations.models import Organization
 
 
-def make_course_key_str(org, number, run='test-run', **kwargs):
-    '''
+def make_course_key_str(org, number, run='test-run'):
+    """
     Helper method to create a string representation of a CourseKey
-    '''
+    """
     return 'course-v1:{}+{}+{}'.format(org, number, run)
 
 
 def create_metrics_model_timeseries(factory, first_day, last_day):
+    """
+    Convenience method to create a set of time series factory objects
+    """
     return [factory(date_for=dt)
             for dt in rrule(DAILY, dtstart=first_day, until=last_day)]
 
@@ -28,21 +29,8 @@ def organizations_support_sites():
 
     This is used to conditionally run tests
     """
-    orgs_has_site = hasattr(organizations.models.Organization, 'sites')
+    orgs_has_site = hasattr(Organization, 'sites')
     return orgs_has_site
-
-
-def add_user_to_site(user, site):
-    orgs = figures.sites.get_organizations_for_site(site)
-    assert orgs.count() == 1, 'requires a single org for the site. Found {}'.format(
-        orgs.count())
-    if not organizations.models.UserOrganizationMapping.objects.filter(
-        user=user, organization=orgs.first()).exists():
-        obj, created = organizations.models.UserOrganizationMapping.objects.get_or_create(
-            user=user,
-            organization=orgs[0],
-        )
-        return obj, created
 
 
 def django_filters_pre_v1():
@@ -50,4 +38,3 @@ def django_filters_pre_v1():
     """
     import django_filters
     return version.parse(django_filters.__version__) < version.parse('1.0.0')
-

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -40,17 +40,28 @@ series sets
 import datetime
 
 from dateutil.rrule import rrule, DAILY
-import mock
 import pytest
 
 from django.contrib.sites.models import Site
 from django.utils.timezone import utc
 
-import organizations
+from figures.metrics import (
+    get_active_users_for_time_period,
+    get_course_average_days_to_complete_for_time_period,
+    get_course_average_progress_for_time_period,
+    get_course_enrolled_users_for_time_period,
+    get_course_num_learners_completed_for_time_period,
+    get_monthly_site_metrics,
+    get_total_course_completions_for_time_period,
+    get_total_enrollments_for_time_period,
+    get_total_site_courses_for_time_period,
+    get_total_site_users_for_time_period,
+    get_total_site_users_joined_for_time_period,
 
-from figures import metrics
+)
 import figures.helpers
-import figures.sites
+
+from figures.sites import get_organizations_for_site
 
 from tests.factories import (
     CourseDailyMetricsFactory,
@@ -62,29 +73,16 @@ from tests.factories import (
     StudentModuleFactory,
     UserFactory,
     )
-from tests.helpers import add_user_to_site, organizations_support_sites
+from tests.helpers import organizations_support_sites
 
-# TODO:
+if organizations_support_sites():
+    from tests.factories import UserOrganizationMappingFactory
 
-# - build set of User, StudentModule, CourseOverview objects to test the
-# StudentModule based methods and classes
 
 # Test with a date range where there is at least one month in the middle
 DEFAULT_START_DATE = datetime.datetime(2018, 1, 1, 0, 0, tzinfo=utc)
 DEFAULT_END_DATE = datetime.datetime(2018, 3, 1, 0, 0, tzinfo=utc)
 
-
-def add_course_to_site(course_id, site):
-    orgs = figures.sites.get_organizations_for_site(site)
-    assert orgs.count() == 1, 'requires a single org for the site. Found {}'.format(
-        orgs.count())
-    if not organizations.models.OrganizationCourse.objects.filter(
-        course_id=str(course_id), organization=orgs.first()).exists():
-        obj, created = organizations.models.OrganizationCourse.objects.get_or_create(
-            course_id=str(course_id),
-            organization=orgs[0],
-        )
-        return obj, created
 
 def create_student_module_test_data(start_date, end_date):
     '''
@@ -195,25 +193,28 @@ def create_course_daily_metrics_data(site, start_date, end_date, course_id=None)
 
 
 def create_users_joined_over_time(site, is_multisite, start_date, end_date):
-    '''
-    creates users. Each user joins on a succesive date between the dates
+    """
+    Creates users. Each user joins on a succesive date between the dates
     pass as arguments
-    '''
+    """
     users = []
     for dt in rrule(DAILY, dtstart=start_date, until=end_date):
         user = UserFactory(date_joined=dt)
         if is_multisite:
-            add_user_to_site(user=user, site=site)
+            orgs = get_organizations_for_site(site)
+            assert orgs.count() == 1
+            UserOrganizationMappingFactory(user=user, organization=orgs[0])
         users.append(user)
     return users
 
 
 @pytest.mark.django_db
 class TestGetMonthlySiteMetrics(object):
-    '''
+    """
     This test also exercises the time period getters used in
-    metrics.get_monthly_site_metrics
-    '''
+    figures.metrics.get_monthly_site_metrics
+    """
+
     @pytest.fixture(autouse=True)
     def setup(self, db):
         self.today = datetime.datetime(2018, 1, 6, tzinfo=utc)
@@ -232,7 +233,7 @@ class TestGetMonthlySiteMetrics(object):
     #     ])
     def test_get_today(self):
         date_for = self.today
-        data = metrics.get_monthly_site_metrics(date_for=date_for)
+        data = get_monthly_site_metrics(date_for=date_for)
         assert set(data.keys()) == self.expected_keys
 
 
@@ -273,15 +274,13 @@ class TestSiteMetricsGettersStandalone(object):
 
         student_module_sets = []
         for i in range(0, 3):
-            data = create_student_module_test_data(
-                    start_date=self.data_start_date,
-                    end_date=self.data_end_date)
+            data = create_student_module_test_data(start_date=self.data_start_date,
+                                                   end_date=self.data_end_date)
             student_module_sets.append(data)
 
-        count = metrics.get_active_users_for_time_period(
-            site=self.site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
+        count = get_active_users_for_time_period(site=self.site,
+                                                 start_date=self.data_start_date,
+                                                 end_date=self.data_end_date)
         assert count == len(student_module_sets)
 
     def test_get_total_site_users_for_time_period(self):
@@ -296,12 +295,11 @@ class TestSiteMetricsGettersStandalone(object):
             is_multisite=figures.helpers.is_multisite(),
             start_date=self.data_start_date,
             end_date=self.data_end_date)
-        count = metrics.get_total_site_users_for_time_period(
+        count = get_total_site_users_for_time_period(
             site=self.site,
             start_date=self.data_start_date,
             end_date=self.data_end_date,
-            calc_raw=True,
-            )
+            calc_raw=True)
         assert count == len(users)
 
     def test_get_total_site_users_joined_for_time_period(self):
@@ -314,7 +312,7 @@ class TestSiteMetricsGettersStandalone(object):
             is_multisite=figures.helpers.is_multisite(),
             start_date=self.data_start_date,
             end_date=self.data_end_date)
-        count = metrics.get_total_site_users_joined_for_time_period(
+        count = get_total_site_users_joined_for_time_period(
             site=self.site,
             start_date=self.data_start_date,
             end_date=self.data_end_date)
@@ -325,10 +323,9 @@ class TestSiteMetricsGettersStandalone(object):
         We're incrementing values for test data, so the last SiteDailyMetrics
         record will have the max value
         '''
-        count = metrics.get_total_enrollments_for_time_period(
-            site=self.site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
+        count = get_total_enrollments_for_time_period(site=self.site,
+                                                      start_date=self.data_start_date,
+                                                      end_date=self.data_end_date)
 
         assert count == self.site_daily_metrics[-1].total_enrollment_count
 
@@ -337,10 +334,9 @@ class TestSiteMetricsGettersStandalone(object):
         We're incrementing values for test data, so the last SiteDailyMetrics
         record will have the max value
         '''
-        count = metrics.get_total_site_courses_for_time_period(
-            site=self.site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
+        count = get_total_site_courses_for_time_period(site=self.site,
+                                                       start_date=self.data_start_date,
+                                                       end_date=self.data_end_date)
 
         assert count == self.site_daily_metrics[-1].course_count
 
@@ -354,10 +350,9 @@ class TestSiteMetricsGettersStandalone(object):
             site=self.site,
             start_date=self.data_start_date,
             end_date=self.data_end_date)
-        count = metrics.get_total_course_completions_for_time_period(
-            site=self.site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
+        count = get_total_course_completions_for_time_period(site=self.site,
+                                                             start_date=self.data_start_date,
+                                                             end_date=self.data_end_date)
         assert count == cdm[-1].num_learners_completed
 
     def test_get_monthly_site_metrics(self):
@@ -374,7 +369,7 @@ class TestSiteMetricsGettersStandalone(object):
         ]
         expected_2nd_lvl_keys = ['current_month', 'history']
         expected_history_elem_keys = ['period', 'value']
-        actual = metrics.get_monthly_site_metrics(site=self.site)
+        actual = get_monthly_site_metrics(site=self.site)
 
         assert set(actual.keys()) == set(expected_top_lvl_keys)
         for key, val in actual.iteritems():
@@ -402,14 +397,14 @@ class TestSiteMetricsGettersMultisite(object):
         self.data_end_date = DEFAULT_END_DATE
 
         self.alpha_site = SiteFactory(domain='alpha.site')
-        self.alpha_org =  OrganizationFactory(sites=[self.alpha_site])
+        self.alpha_org = OrganizationFactory(sites=[self.alpha_site])
         self.alpha_site_daily_metrics = create_site_daily_metrics_data(
             site=self.alpha_site,
             start_date=self.data_start_date,
             end_date=self.data_end_date)
 
         self.bravo_site = SiteFactory(domain='bravo.site')
-        self.bravo_org =  OrganizationFactory(sites=[self.bravo_site])
+        self.bravo_org = OrganizationFactory(sites=[self.bravo_site])
         self.bravo_site_daily_metrics = create_site_daily_metrics_data(
             site=self.bravo_site,
             start_date=self.data_start_date,
@@ -422,19 +417,16 @@ class TestSiteMetricsGettersMultisite(object):
         assert figures.helpers.is_multisite()
         student_module_sets = []
         for i in range(0, 3):
-            data = create_student_module_test_data(
-                    start_date=self.data_start_date,
-                    end_date=self.data_end_date)
+            data = create_student_module_test_data(start_date=self.data_start_date,
+                                                   end_date=self.data_end_date)
             student_module_sets.append(data)
-            uom, created = add_user_to_site(user=data['user'], site=self.alpha_site)
-            # add course to site
-            org_course, created = add_course_to_site(
-                data['course_overview'].id,
-                site=self.alpha_site)
-        count = metrics.get_active_users_for_time_period(
-            site=self.alpha_site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
+            OrganizationCourseFactory(organization=self.alpha_org,
+                                      course_id=str(data['course_overview'].id))
+            UserOrganizationMappingFactory(user=data['user'],
+                                           organization=self.alpha_org)
+        count = get_active_users_for_time_period(site=self.alpha_site,
+                                                 start_date=self.data_start_date,
+                                                 end_date=self.data_end_date)
 
         assert count == len(student_module_sets)
 
@@ -450,12 +442,10 @@ class TestSiteMetricsGettersMultisite(object):
             is_multisite=figures.helpers.is_multisite(),
             start_date=self.data_start_date,
             end_date=self.data_end_date)
-        count = metrics.get_total_site_users_for_time_period(
-            site=self.alpha_site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date,
-            calc_raw=True,
-            )
+        count = get_total_site_users_for_time_period(site=self.alpha_site,
+                                                     start_date=self.data_start_date,
+                                                     end_date=self.data_end_date,
+                                                     calc_raw=True)
         assert count == len(users)
 
     def test_get_total_site_users_joined_for_time_period(self):
@@ -468,10 +458,9 @@ class TestSiteMetricsGettersMultisite(object):
             is_multisite=figures.helpers.is_multisite(),
             start_date=self.data_start_date,
             end_date=self.data_end_date)
-        count = metrics.get_total_site_users_joined_for_time_period(
-            site=self.alpha_site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
+        count = get_total_site_users_joined_for_time_period(site=self.alpha_site,
+                                                            start_date=self.data_start_date,
+                                                            end_date=self.data_end_date)
         assert count == len(users)
 
     def test_get_total_enrollments_for_time_period(self):
@@ -479,11 +468,9 @@ class TestSiteMetricsGettersMultisite(object):
         We're incrementing values for test data, so the last SiteDailyMetrics
         record will have the max value
         '''
-        count = metrics.get_total_enrollments_for_time_period(
-            site=self.alpha_site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
-
+        count = get_total_enrollments_for_time_period(site=self.alpha_site,
+                                                      start_date=self.data_start_date,
+                                                      end_date=self.data_end_date)
         assert count == self.alpha_site_daily_metrics[-1].total_enrollment_count
 
     def test_get_total_site_courses_for_time_period(self):
@@ -491,11 +478,9 @@ class TestSiteMetricsGettersMultisite(object):
         We're incrementing values for test data, so the last SiteDailyMetrics
         record will have the max value
         '''
-        count = metrics.get_total_site_courses_for_time_period(
-            site=self.alpha_site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
-
+        count = get_total_site_courses_for_time_period(site=self.alpha_site,
+                                                       start_date=self.data_start_date,
+                                                       end_date=self.data_end_date)
         assert count == self.alpha_site_daily_metrics[-1].course_count
 
     def test_get_total_course_completions_for_time_period(self):
@@ -508,7 +493,7 @@ class TestSiteMetricsGettersMultisite(object):
             site=self.alpha_site,
             start_date=self.data_start_date,
             end_date=self.data_end_date)
-        count = metrics.get_total_course_completions_for_time_period(
+        count = get_total_course_completions_for_time_period(
             site=self.alpha_site,
             start_date=self.data_start_date,
             end_date=self.data_end_date)
@@ -528,7 +513,7 @@ class TestSiteMetricsGettersMultisite(object):
         ]
         expected_2nd_lvl_keys = ['current_month', 'history']
         expected_history_elem_keys = ['period', 'value']
-        actual = metrics.get_monthly_site_metrics(site=self.alpha_site)
+        actual = get_monthly_site_metrics(site=self.alpha_site)
 
         assert set(actual.keys()) == set(expected_top_lvl_keys)
         for key, val in actual.iteritems():
@@ -585,7 +570,7 @@ class TestCourseMetricsGettersStandalone(object):
         Validates results against the max value for the metrics model attribute
         '''
         expected = self.course_daily_metrics[-1].enrollment_count
-        actual = metrics.get_course_enrolled_users_for_time_period(
+        actual = get_course_enrolled_users_for_time_period(
             site=self.site,
             start_date=self.data_start_date,
             end_date=self.data_end_date,
@@ -593,7 +578,7 @@ class TestCourseMetricsGettersStandalone(object):
         assert actual == expected
 
     def test_get_course_average_progress_for_time_period(self):
-        actual = metrics.get_course_average_progress_for_time_period(
+        actual = get_course_average_progress_for_time_period(
             site=self.site,
             start_date=self.data_start_date,
             end_date=self.data_end_date,
@@ -601,7 +586,7 @@ class TestCourseMetricsGettersStandalone(object):
         assert actual == self.get_average('average_progress', float)
 
     def test_get_course_average_days_to_complete_for_time_period(self):
-        actual = metrics.get_course_average_days_to_complete_for_time_period(
+        actual = get_course_average_days_to_complete_for_time_period(
             site=self.site,
             start_date=self.data_start_date,
             end_date=self.data_end_date,
@@ -611,7 +596,7 @@ class TestCourseMetricsGettersStandalone(object):
     def test_get_course_num_learners_completed_for_time_period(self):
         expected = max(
             [rec.num_learners_completed for rec in self.course_daily_metrics])
-        actual = metrics.get_course_num_learners_completed_for_time_period(
+        actual = get_course_num_learners_completed_for_time_period(
             site=self.site,
             start_date=self.data_start_date,
             end_date=self.data_end_date,
@@ -679,7 +664,7 @@ class TestCourseMetricsGettersMultisite(object):
         Validates results against the max value for the metrics model attribute
         '''
         expected = self.alpha_course_daily_metrics[-1].enrollment_count
-        actual = metrics.get_course_enrolled_users_for_time_period(
+        actual = get_course_enrolled_users_for_time_period(
             site=self.alpha_site,
             start_date=self.data_start_date,
             end_date=self.data_end_date,
@@ -687,27 +672,29 @@ class TestCourseMetricsGettersMultisite(object):
         assert actual == expected
 
     def test_get_course_average_progress_for_time_period(self):
-        actual = metrics.get_course_average_progress_for_time_period(
+        actual = get_course_average_progress_for_time_period(
             site=self.alpha_site,
             start_date=self.data_start_date,
             end_date=self.data_end_date,
             course_id=self.alpha_course_overview.id)
         assert actual == self.get_average(self.alpha_course_daily_metrics,
-            'average_progress', float)
+                                          'average_progress',
+                                          float)
 
     def test_get_course_average_days_to_complete_for_time_period(self):
-        actual = metrics.get_course_average_days_to_complete_for_time_period(
+        actual = get_course_average_days_to_complete_for_time_period(
             site=self.alpha_site,
             start_date=self.data_start_date,
             end_date=self.data_end_date,
             course_id=self.alpha_course_overview.id)
         assert actual == self.get_average(self.alpha_course_daily_metrics,
-            'average_days_to_complete', int)
+                                          'average_days_to_complete',
+                                          int)
 
     def test_get_course_num_learners_completed_for_time_period(self):
         expected = max(
             [rec.num_learners_completed for rec in self.alpha_course_daily_metrics])
-        actual = metrics.get_course_num_learners_completed_for_time_period(
+        actual = get_course_num_learners_completed_for_time_period(
             site=self.alpha_site,
             start_date=self.data_start_date,
             end_date=self.data_end_date,


### PR DESCRIPTION
@OmarIthawi @melvinsoft This should be a quick one. Just some test code cleanup

Bump Python package versions for test packages for Hawthorn
- Also removed blank line from .coveragerc

Test helpers and test_metrics cleanup
- Removed tests.helpers.add_user_to_site because
  - Only tests.metrics.test_metrics used it
  - It is brittle code, relying on one org per site. We want to free
this constraint in our tests except exactly where needed to test
Site:Organization cardinality
  - Factories do the job cleaner

- Cleaned up tests.metrics.test_metrics to help improve single site/
multisite testing
