### PR TITLE
Avoid GeneratedCertificate import errors

### DIFF
--- a/figures/compat.py
+++ b/figures/compat.py
@@ -26,12 +26,11 @@ except ImportError:
         # try the pre-ginkgo path
         from lms.djangoapps.grades.new.course_grade import CourseGradeFactory    # noqa: F401
 
-try:
-    # First try to import for the path as of hawthorn
-    from lms.djangoapps.certificates.models import GeneratedCertificate
-except ImportError:
-    # try the pre-hawthorn path
-    from certificates.models import GeneratedCertificate    # noqa: F401
+
+if RELEASE_LINE == 'ginkgo':
+    from certificates.models import GeneratedCertificate  # noqa: F401
+else:
+    from lms.djangoapps.certificates.models import GeneratedCertificate  # noqa: F401
 
 
 def course_grade(learner, course):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -7,7 +7,7 @@ NOTE
 ====
 
 Pytest monkeypatch does not support testing imports as it does not undo updating
-entries in sys.modules. Therefore, we need to use mock.patch context manager.
+entries in sys.modules. Therefore, we need to use patch context manager.
 
 '''
 
@@ -16,18 +16,47 @@ entries in sys.modules. Therefore, we need to use mock.patch context manager.
 # wipe the branch, pull from develop and create new branch. Fastest
 
 
-import mock
+from mock import Mock, patch
 import pytest
-import types
+import six
+from types import ModuleType
 
 
+def patch_module(module_path, extra_properties=None):
+    """
+    Patch an entirely new module.
+
+    This can be used as both decorator or a context (e.g. `with patch_module(...):`).
+
+    :param module_path: lms.djangoapps.certificates.models
+    :param extra_properties: {'SomeClass': Mock()}
+    :return:
+    """
+    if not module_path:
+        raise ValueError('module_path is required')
+
+    path_parts = module_path.split('.')
+    patch_specs = {}
+
+    for i, part in enumerate(path_parts):
+        sub_path = '.'.join(path_parts[:i+1])
+        print('sub_path', sub_path)
+        module = ModuleType(sub_path)
+        patch_specs[sub_path] = module
+
+        if i == (len(path_parts) - 1):  # Leaf module
+            if extra_properties:
+                for key, value in six.iteritems(extra_properties):
+                    setattr(module, key, value)
+
+    return patch.dict('sys.modules', patch_specs)
+
+
+@patch('openedx.core.release.RELEASE_LINE', 'ginkgo')
 def test_release_line_with_ginkgo():
     '''Make sure that ``figures.compat.RELEASE_LINE`` is 'ginkgo'
     '''
-    release_module = mock.MagicMock()
-    setattr(release_module, 'RELEASE_LINE', 'ginkgo')
-
-    with mock.patch.dict('sys.modules', {'openedx.core.release': release_module}):
+    with patch_module('certificates.models', {'GeneratedCertificate': Mock()}):  # Just to avoid an error
         import figures.compat
         reload(figures.compat)
         assert figures.compat.RELEASE_LINE == 'ginkgo'
@@ -35,58 +64,41 @@ def test_release_line_with_ginkgo():
 
 # For the ginkgo tests, we need to first remove finding the hawthorn module
 
-
 def test_course_grade_factory_with_ginkgo():
     hawthorn_key = 'lms.djangoapps.grades.course_grade_factory'
-    namespaces = ['lms.djangoapps.grades.new',
-                   'lms.djangoapps.grades.new.course_grade_factory']
-    modules = [types.ModuleType(ns) for ns in namespaces]
-    modules[0].course_grade_factory = modules[1]
-    setattr(modules[1], 'CourseGradeFactory', 'hi')
-    with mock.patch.dict('sys.modules', {hawthorn_key: None}):
-        with mock.patch.dict('sys.modules', {namespaces[0]: modules[0]}):
-            with mock.patch.dict('sys.modules', {namespaces[1]: modules[1]}):
-                import figures.compat
-                reload(figures.compat)
-                assert figures.compat.CourseGradeFactory == 'hi'
+    with patch.dict('sys.modules', {hawthorn_key: None}):
+        with patch_module('lms.djangoapps.grades.new.course_grade_factory', {'CourseGradeFactory': 'hi'}):
+            import figures.compat
+            reload(figures.compat)
+            assert figures.compat.CourseGradeFactory == 'hi'
 
 
+@patch('openedx.core.release.RELEASE_LINE', 'hawthorn')
 def test_course_grade_factory_with_hawthorn():
-    key = 'lms.djangoapps.grades.course_grade_factory'
-    module = mock.Mock()
-    setattr(module, 'CourseGradeFactory', 'hi')
-    with mock.patch.dict('sys.modules', {key: module}):
-        import figures.compat
-        reload(figures.compat)
-        assert hasattr(figures.compat, 'CourseGradeFactory')
-        assert figures.compat.CourseGradeFactory == 'hi'
+    with patch_module('lms.djangoapps.certificates.models', {'GeneratedCertificate': Mock()}):  # Just to avoid an error
+        with patch_module('lms.djangoapps.grades.course_grade_factory', {'CourseGradeFactory': 'hi'}):
+            import figures.compat
+            reload(figures.compat)
+            assert hasattr(figures.compat, 'CourseGradeFactory')
+            assert figures.compat.CourseGradeFactory == 'hi'
 
 
+@patch('openedx.core.release.RELEASE_LINE', 'ginkgo')
 def test_generated_certificate_pre_hawthorn():
-    hawthorn_key = 'lms.djangoapps.certificates.models'
-    pre_haw_namespaces = ['certificates', 'certificates.models']
-    modules = [types.ModuleType(ns) for ns in pre_haw_namespaces]
-    modules[0].models = modules[1]
-    setattr(modules[1], 'GeneratedCertificate', 'hi')
-    with mock.patch.dict('sys.modules', {hawthorn_key: None}):
-        with mock.patch.dict('sys.modules', {pre_haw_namespaces[0]: modules[0]}):
-            with mock.patch.dict('sys.modules', {pre_haw_namespaces[1]: modules[1]}):
-                import figures.compat
-                reload(figures.compat)
-                assert hasattr(figures.compat, 'GeneratedCertificate')
-                assert figures.compat.GeneratedCertificate == 'hi'
-
-
-@pytest.mark.skip('ginkgo backport')
-def test_generated_certificate_hawthorn():
-    hawthorn_key = 'lms.djangoapps.certificates.models'
-    module = mock.Mock()
-    setattr(module, 'GeneratedCertificate', 'hi')
-    with mock.patch.dict('sys.modules', {hawthorn_key: module}):
+    mock =  Mock()
+    with patch_module('certificates.models', {'GeneratedCertificate': mock}):
         import figures.compat
         reload(figures.compat)
         assert hasattr(figures.compat, 'GeneratedCertificate')
-        import pdb; pdb.set_trace()
+        assert figures.compat.GeneratedCertificate is mock
+
+
+def test_generated_certificate_hawthorn():
+    hawthorn_key = 'lms.djangoapps.certificates.models'
+    with patch_module(hawthorn_key, {'GeneratedCertificate': 'hi'}):
+        import figures.compat
+        reload(figures.compat)
+        assert hasattr(figures.compat, 'GeneratedCertificate')
         assert figures.compat.GeneratedCertificate == 'hi'
 
 


### PR DESCRIPTION
Using explicit RELEASE_LINE check to avoid the issue.

I don't have a devstack to verify it, but I think it's possible that `lms.djangoapps.certificates.models import GeneratedCertificate` is succeeding on Ginkgo and that would confuse the Django database migration system.

Doing the explicit check ensures that we don't have this issue.