### PR TITLE
small style fix on course link button

### DIFF
--- a/frontend/src/views/_single-course-content.scss
+++ b/frontend/src/views/_single-course-content.scss
@@ -15,7 +15,7 @@
     background-color: #ccc;
   }
 
-  &__link {
+  &__link, &__link:not(.btn), &__link:visited:not(.btn) {
     display: inline-block;
     padding: calcRem(8) calcRem(12);
     font-size: $base-font-size;


### PR DESCRIPTION
Some edX styles were overriding the button style for the button on course analytics page that takes the user to the courseware itself. Super simple.