### PR TITLE
Enable `codecov/patch` again

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    patch: false
-    project:
-      default:
-        target: 85%
-        threshold: 10%


### PR DESCRIPTION
This should solve the issue [**RED-657:** Codecov/patch gets stuck with the message "Expected — Waiting for status to be reported" ](https://appsembler.atlassian.net/browse/RED-657).

### A bit of a background
During the Ginkgo backport John have asked to disable the `patch` because it was broken without an immediate solution so Anders disabled `codecov/patch` in #150, this PR should enable the `codecov/patch` again because we wanted it again now.