### PR TITLE
Update Travis to use Yarn instead of NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ node_js:
 install:
   - pip install -r devsite/requirements/hawthorn_community.txt
   - pip install pytest-cov flake8 tox
-  - cd frontend && npm install && cd ..
+  - cd frontend && yarn && cd ..
 
 # command to run tests
 script:
-  - cd frontend && npm run-script build && cd ..
+  - cd frontend && yarn && cd ..
   - flake8 figures
   - py.test --cov=./
   - bash <(curl -s https://codecov.io/bash)

--- a/DEVELOPER-QUICKSTART.md
+++ b/DEVELOPER-QUICKSTART.md
@@ -42,6 +42,22 @@ pytest
 
 ## 4. Build front end assets
 
+Figures front end assets need to be build from the front end sources. Make sure you have (Yarn)[https://yarnpkg.com/lang/en/] installed. Then do the following:
+
+Navigate to the `figures/frontend` directory.
+
+
+Then download JavaScript dependencies:
+
+```
+yarn
+```
+
+Then compile Figures front end assets:
+
+```
+yarn build
+```
 
 ## 5. Set up Figures standalone server
 
@@ -67,37 +83,6 @@ Next, seed the devsite database with mock data. Run the following:
 ```
 
 The `seed_data` command populates the dev server with mock data then builds metrics on the mock data, backfilling historical data (experimental feature)
-
-Finally, Figures front end assets need to be build from the front end sources. If you have (Yarn)[https://yarnpkg.com/lang/en/] installed, then you can run the following.
-
-First navigate to the `figures/frontend` directory.
-
-
-Then download JavaScript dependencies:
-
-```
-yarn
-```
-
-Then compile Figures front end assets:
-
-```
-yarn build
-```
-
-Alternately, you can run NPM:
-
-To download JavaScript dependencies:
-```
-npm install
-```
-
-To compile Figures front end assets:
-
-```
-npm run-script build
-```
-
 
 ## 6. Starting Figures devsite
 


### PR DESCRIPTION
- Replaced calls to `npm` with calls to `yarn` to install JavaScript
dependencies and build the Figures front end assets
- Updatdd Developer quickstart guide to build front end assets with Yan


This PR (#167) replaces this one: https://github.com/appsembler/figures/pull/166