### PR TITLE
API update - Adds SiteMonthlyMetrics viewset

### DIFF
--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -111,7 +111,8 @@ def prev_day(val):
 
 
 def days_in_month(month_for):
-    return calendar.monthrange(month_for.year, month_for.month)[1]
+    _, num_days_in_month = calendar.monthrange(month_for.year, month_for.month)
+    return num_days_in_month
 
 
 # TODO: Consider changing name to 'months_back_iterator' or similar

--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -110,6 +110,10 @@ def prev_day(val):
     return days_from(val, -1)
 
 
+def days_in_month(month_for):
+    return calendar.monthrange(month_for.year, month_for.month)[1]
+
+
 # TODO: Consider changing name to 'months_back_iterator' or similar
 # TODO: implement or removed include_month_for
 def previous_months_iterator(month_for, months_back, include_month_for=False):
@@ -128,5 +132,5 @@ def previous_months_iterator(month_for, months_back, include_month_for=False):
         start_month = month_for - relativedelta(months=months_back)
 
     for dt in rrule(freq=MONTHLY, dtstart=start_month, until=month_for):
-        last_day_of_month = calendar.monthrange(dt.year, dt.month)[1]
+        last_day_of_month = days_in_month(month_for=dt)
         yield (dt.year, dt.month, last_day_of_month)

--- a/figures/metrics.py
+++ b/figures/metrics.py
@@ -40,6 +40,7 @@ from figures.helpers import (
     as_course_key,
     as_date,
     as_datetime,
+    days_in_month,
     next_day,
     prev_day,
     previous_months_iterator,
@@ -498,6 +499,44 @@ def get_monthly_history_metric(func, site, date_for, months_back,
     return dict(
         current_month=current_month,
         history=history,)
+
+
+def get_current_month_site_metrics(site, **kwargs):
+    """
+    TODO: put the metric names and functions in a dict and iterate. This then
+    will let up dynamically retrieve fields for the monthly metrics this function
+    returns
+    """
+    date_for = datetime.datetime.utcnow().date()
+    start_date = datetime.date(year=date_for.year, month=date_for.month, day=1)
+    end_date = datetime.date(year=date_for.year,
+                             month=date_for.month,
+                             day=days_in_month(date_for))
+
+    active_users = get_active_users_for_time_period(site=site,
+                                                    start_date=start_date,
+                                                    end_date=end_date)
+    registered_users = get_total_site_users_for_time_period(site=site,
+                                                            start_date=start_date,
+                                                            end_date=end_date)
+    new_users = get_total_site_users_joined_for_time_period(site=site,
+                                                            start_date=start_date,
+                                                            end_date=end_date)
+    site_courses = get_total_site_courses_for_time_period(site=site,
+                                                          start_date=start_date,
+                                                          end_date=end_date)
+    course_enrollments = get_total_enrollments_for_time_period(site=site,
+                                                               start_date=start_date,
+                                                               end_date=end_date)
+    course_completions = get_total_course_completions_for_time_period(site=site,
+                                                                      start_date=start_date,
+                                                                      end_date=end_date)
+    return dict(active_users=active_users,
+                registered_users=registered_users,
+                new_users=new_users,
+                site_courses=site_courses,
+                course_enrollments=course_enrollments,
+                course_completions=course_completions)
 
 
 def get_monthly_site_metrics(site, date_for=None, **kwargs):

--- a/figures/metrics.py
+++ b/figures/metrics.py
@@ -264,7 +264,7 @@ def get_total_site_users_for_time_period(site, start_date, end_date, **kwargs):
     """
     def calc_from_user_model():
         filter_args = dict(
-            date_joined__lt=next_day(end_date),
+            date_joined__lt=as_datetime(next_day(end_date)),
         )
         users = figures.sites.get_users_for_site(site)
         return users.filter(**filter_args).count()
@@ -280,10 +280,10 @@ def get_total_site_users_for_time_period(site, start_date, end_date, **kwargs):
         else:
             return 0
 
-    if kwargs.get('calc_raw'):
-        return calc_from_user_model()
-    else:
+    if kwargs.get('calc_from_sdm'):
         return calc_from_site_daily_metrics()
+    else:
+        return calc_from_user_model()
 
 
 def get_total_site_users_joined_for_time_period(site, start_date, end_date, course_ids=None):
@@ -293,8 +293,8 @@ def get_total_site_users_joined_for_time_period(site, start_date, end_date, cour
     """
     def calc_from_user_model():
         filter_args = dict(
-            date_joined__gt=prev_day(start_date),
-            date_joined__lt=next_day(end_date),
+            date_joined__gt=as_datetime(prev_day(start_date)),
+            date_joined__lt=as_datetime(next_day(end_date)),
         )
         users = figures.sites.get_users_for_site(site)
         return users.filter(**filter_args).values('id').distinct().count()

--- a/figures/urls.py
+++ b/figures/urls.py
@@ -20,6 +20,11 @@ router.register(
     base_name='site-daily-metrics')
 
 router.register(
+    r'site-monthly-metrics',
+    views.SiteMonthlyMetricsViewSet,
+    base_name='site-monthly-metrics')
+
+router.register(
     r'course-mau-metrics',
     views.CourseMauMetricsViewSet,
     base_name='course-mau-metrics')
@@ -81,7 +86,6 @@ router.register(
     r'users/detail',
     views.LearnerDetailsViewSet,
     base_name='users-detail')
-
 
 # TODO: Consider changing this path to be 'users' or 'users/summary'
 # So that all user data fall under the same root path

--- a/figures/views.py
+++ b/figures/views.py
@@ -248,6 +248,10 @@ class SiteDailyMetricsViewSet(CommonAuthMixin, viewsets.ModelViewSet):
 class GeneralSiteMetricsView(CommonAuthMixin, APIView):
     """Viewset intended for Figures Web UI
 
+    DEPRECATED. This view is deprecated
+
+    TODO: Determine when we remove this class
+
     Initial version assumes a single site.
     Multi-tenancy will add a Site foreign key to the SiteDailyMetrics model
     and list the most recent data for all sites (or filtered sites)
@@ -379,28 +383,12 @@ class LearnerDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
         context['site'] = django.contrib.sites.shortcuts.get_current_site(self.request)
         return context
 
-    @list_route()
-    def registered_learners(self, request):
-        # serializer = UserRegistrationMetrics
-        # return Response(serliazer.data)
-
-        import pdb; pdb.set_trace()
-        data = dict(
-            registered_learners=42,
-        )
-        return Response(data)
-
-
-#
-# Indidual metrics views for historical metrics
-#
-
 
 class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
     """Serves sitewide metrics
 
     TODO:
-    * Make months_back be a query param
+    * Make months_back be a query param.
     * Create a decorator to do the duplicate work in these methods
     * Improve test coverage
     * Create viewsets for `SiteMetricsViewSet`, `UserMetricsViewSet`
@@ -409,27 +397,24 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
     ## Dev note
     Does it benefit to make serializers for these calls?
     Do we want to create a SiteMonthlyMetrics model?
+    If we do, then we can also use django-filter on the model
     Tradeoff: Additional storage cost to reduced request time
     Perhaps we make this a server setting
     """
-    filter_backends = (DjangoFilterBackend, )
-    # filter_class = SiteMonthlyMetricsFilterSet
+    def list(self, request):
+        """
+        Returns site metrics data for current month
+        """
 
-    def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
-        queryset = figures.sites.get_users_for_site(site)
-        return queryset
+        data = metrics.get_current_month_site_metrics(site)
+        return Response(data)
 
-    def get_serializer_context(self):
-        context = super(UserMetricsViewSet, self).get_serializer_context()
-        context['site'] = django.contrib.sites.shortcuts.get_current_site(self.request)
-        return context
-
-    # @list_route()
+    @list_route()
     def registered_users(self, request):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
         date_for = datetime.utcnow().date()
-        months_back=6
+        months_back = 6
 
         registered_users = metrics.get_monthly_history_metric(
             func=metrics.get_total_site_users_for_time_period,
@@ -444,7 +429,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
     def new_users(self, request):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
         date_for = datetime.utcnow().date()
-        months_back=6
+        months_back = 6
 
         new_users = metrics.get_monthly_history_metric(
             func=metrics.get_total_site_users_joined_for_time_period,
@@ -459,7 +444,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
     def course_completions(self, request):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
         date_for = datetime.utcnow().date()
-        months_back=6
+        months_back = 6
 
         course_completions = metrics.get_monthly_history_metric(
             func=metrics.get_total_site_users_for_time_period,
@@ -474,7 +459,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
     def course_enrollments(self, request):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
         date_for = datetime.utcnow().date()
-        months_back=6
+        months_back = 6
 
         course_enrollments = metrics.get_monthly_history_metric(
             func=metrics.get_total_enrollments_for_time_period,
@@ -489,7 +474,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
     def site_courses(self, request):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
         date_for = datetime.utcnow().date()
-        months_back=6
+        months_back = 6
 
         site_courses = metrics.get_monthly_history_metric(
             func=metrics.get_total_site_courses_for_time_period,
@@ -504,7 +489,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
     def active_users(self, request):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
         date_for = datetime.utcnow().date()
-        months_back=6
+        months_back = 6
 
         active_users = metrics.get_monthly_history_metric(
             func=metrics.get_active_users_for_time_period,

--- a/figures/views.py
+++ b/figures/views.py
@@ -1,6 +1,7 @@
 """Figures views
 """
 
+from datetime import datetime
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required, user_passes_test
 import django.contrib.sites.shortcuts
@@ -15,6 +16,7 @@ from rest_framework.authentication import (
     SessionAuthentication,
     TokenAuthentication,
 )
+from rest_framework.decorators import list_route
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.filters import DjangoFilterBackend
@@ -244,11 +246,12 @@ class SiteDailyMetricsViewSet(CommonAuthMixin, viewsets.ModelViewSet):
 
 
 class GeneralSiteMetricsView(CommonAuthMixin, APIView):
-    '''
+    """Viewset intended for Figures Web UI
+
     Initial version assumes a single site.
     Multi-tenancy will add a Site foreign key to the SiteDailyMetrics model
     and list the most recent data for all sites (or filtered sites)
-    '''
+    """
 
     pagination_class = FiguresLimitOffsetPagination
 
@@ -277,9 +280,8 @@ class GeneralSiteMetricsView(CommonAuthMixin, APIView):
 
 
 class GeneralCourseDataViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
-    '''
-
-    '''
+    """Viewset intended for Figures Web UI
+    """
     model = CourseOverview
 
     # The "kilo paginator"  is a tempoarary hack to return all course to not
@@ -376,6 +378,147 @@ class LearnerDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
         context = super(LearnerDetailsViewSet, self).get_serializer_context()
         context['site'] = django.contrib.sites.shortcuts.get_current_site(self.request)
         return context
+
+    @list_route()
+    def registered_learners(self, request):
+        # serializer = UserRegistrationMetrics
+        # return Response(serliazer.data)
+
+        import pdb; pdb.set_trace()
+        data = dict(
+            registered_learners=42,
+        )
+        return Response(data)
+
+
+#
+# Indidual metrics views for historical metrics
+#
+
+
+class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
+    """Serves sitewide metrics
+
+    TODO:
+    * Make months_back be a query param
+    * Create a decorator to do the duplicate work in these methods
+    * Improve test coverage
+    * Create viewsets for `SiteMetricsViewSet`, `UserMetricsViewSet`
+    #   `CourseMetricsViewSet` for retrieving live data for each context
+
+    ## Dev note
+    Does it benefit to make serializers for these calls?
+    Do we want to create a SiteMonthlyMetrics model?
+    Tradeoff: Additional storage cost to reduced request time
+    Perhaps we make this a server setting
+    """
+    filter_backends = (DjangoFilterBackend, )
+    # filter_class = SiteMonthlyMetricsFilterSet
+
+    def get_queryset(self):
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        queryset = figures.sites.get_users_for_site(site)
+        return queryset
+
+    def get_serializer_context(self):
+        context = super(UserMetricsViewSet, self).get_serializer_context()
+        context['site'] = django.contrib.sites.shortcuts.get_current_site(self.request)
+        return context
+
+    # @list_route()
+    def registered_users(self, request):
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        date_for = datetime.utcnow().date()
+        months_back=6
+
+        registered_users = metrics.get_monthly_history_metric(
+            func=metrics.get_total_site_users_for_time_period,
+            site=site,
+            date_for=date_for,
+            months_back=months_back,
+        )
+        data = dict(registered_users=registered_users)
+        return Response(data)
+
+    @list_route()
+    def new_users(self, request):
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        date_for = datetime.utcnow().date()
+        months_back=6
+
+        new_users = metrics.get_monthly_history_metric(
+            func=metrics.get_total_site_users_joined_for_time_period,
+            site=site,
+            date_for=date_for,
+            months_back=months_back,
+        )
+        data = dict(new_users=new_users)
+        return Response(data)
+
+    @list_route()
+    def course_completions(self, request):
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        date_for = datetime.utcnow().date()
+        months_back=6
+
+        course_completions = metrics.get_monthly_history_metric(
+            func=metrics.get_total_site_users_for_time_period,
+            site=site,
+            date_for=date_for,
+            months_back=months_back,
+        )
+        data = dict(course_completions=course_completions)
+        return Response(data)
+
+    @list_route()
+    def course_enrollments(self, request):
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        date_for = datetime.utcnow().date()
+        months_back=6
+
+        course_enrollments = metrics.get_monthly_history_metric(
+            func=metrics.get_total_enrollments_for_time_period,
+            site=site,
+            date_for=date_for,
+            months_back=months_back,
+        )
+        data = dict(course_enrollments=course_enrollments)
+        return Response(data)
+
+    @list_route()
+    def site_courses(self, request):
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        date_for = datetime.utcnow().date()
+        months_back=6
+
+        site_courses = metrics.get_monthly_history_metric(
+            func=metrics.get_total_site_courses_for_time_period,
+            site=site,
+            date_for=date_for,
+            months_back=months_back,
+        )
+        data = dict(site_courses=site_courses)
+        return Response(data)
+
+    @list_route()
+    def active_users(self, request):
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        date_for = datetime.utcnow().date()
+        months_back=6
+
+        active_users = metrics.get_monthly_history_metric(
+            func=metrics.get_active_users_for_time_period,
+            site=site,
+            date_for=date_for,
+            months_back=months_back,
+        )
+        data = dict(active_users=active_users)
+        return Response(data)
+
+
+#
+# MAU metrics views
+#
 
 
 class CourseMauLiveMetricsViewSet(CommonAuthMixin, viewsets.GenericViewSet):

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -325,8 +325,7 @@ class TestSiteMetricsGettersStandalone(object):
         count = get_total_site_users_for_time_period(
             site=self.site,
             start_date=self.data_start_date,
-            end_date=self.data_end_date,
-            calc_raw=True)
+            end_date=self.data_end_date)
         assert count == len(users)
 
     def test_get_total_site_users_joined_for_time_period(self):
@@ -471,8 +470,7 @@ class TestSiteMetricsGettersMultisite(object):
             end_date=self.data_end_date)
         count = get_total_site_users_for_time_period(site=self.alpha_site,
                                                      start_date=self.data_start_date,
-                                                     end_date=self.data_end_date,
-                                                     calc_raw=True)
+                                                     end_date=self.data_end_date)
         assert count == len(users)
 
     def test_get_total_site_users_joined_for_time_period(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,15 +1,60 @@
-'''Test Figures Django management commands
+"""Test Figures Django management commands
+"""
 
-'''
-
+import mock
+import pytest
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils.six import StringIO
 
+
 class PopulateFiguresMetricsTest(TestCase):
+
     def test_command_output(self):
         out = StringIO()
         call_command('populate_figures_metrics', '--no-delay', stdout=out)
 
         self.assertEqual('', out.getvalue())
-        #self.assertIn('Expected output', out.getvalue())
+
+
+def test_mau_no_delay(monkeypatch):
+    """
+    We test that `populate_figures_metrics` command executes the method,
+    `figures.tasks.populate_all_mau` in immediate mode "no delay"
+
+    Tried to use `mock.patch` on the following:
+        'figures.management.commands.populate_figures_metrics.populate_all_mau'
+    See the test function`test_mau_no_delay_with_mock` below for details
+    """
+    call_list = []
+
+    def mock_populate_all_mau():
+        """Mocks the function `figures.tasks.populate_all_mau`
+
+        The function `populate_all_mau` does not return a value, so we modify a
+        variable in our parent test function to assert that the mock method was
+        called. Because of Python's inner function scoping rules, we can read
+        but cannot change them. However, this seems limited to instance variables.
+        Reference variables appear to not have this limitation. Therefore, we
+        append to a list in our outer function.
+        """
+        call_list.append(True)
+
+    path = 'figures.management.commands.populate_figures_metrics.populate_all_mau'
+    monkeypatch.setattr(path, mock_populate_all_mau)
+    call_command('populate_figures_metrics', '--no-delay', '--mau')
+    assert len(call_list) == 1
+
+
+@pytest.mark.skip('This test does not work')
+def test_mau_no_delay_with_mock(transactional_db):
+    """
+    This would be the preferred test to the above. Acccording to the documentation,
+    this should work, but the mock never gets called, so something is not right
+
+    https://docs.python.org/dev/library/unittest.mock.html#where-to-patch
+    """
+    path = 'figures.management.commands.populate_figures_metrics.populate_all_mau'
+    with mock.patch(path) as mock_populate_all_mau:
+        call_command('populate_figures_metrics', '--no-delay')
+        mock_populate_all_mau.assert_called()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,44 +17,12 @@ class PopulateFiguresMetricsTest(TestCase):
         self.assertEqual('', out.getvalue())
 
 
-def test_mau_no_delay(monkeypatch):
+def test_mau_no_delay(transactional_db):
     """
     We test that `populate_figures_metrics` command executes the method,
     `figures.tasks.populate_all_mau` in immediate mode "no delay"
-
-    Tried to use `mock.patch` on the following:
-        'figures.management.commands.populate_figures_metrics.populate_all_mau'
-    See the test function`test_mau_no_delay_with_mock` below for details
-    """
-    call_list = []
-
-    def mock_populate_all_mau():
-        """Mocks the function `figures.tasks.populate_all_mau`
-
-        The function `populate_all_mau` does not return a value, so we modify a
-        variable in our parent test function to assert that the mock method was
-        called. Because of Python's inner function scoping rules, we can read
-        but cannot change them. However, this seems limited to instance variables.
-        Reference variables appear to not have this limitation. Therefore, we
-        append to a list in our outer function.
-        """
-        call_list.append(True)
-
-    path = 'figures.management.commands.populate_figures_metrics.populate_all_mau'
-    monkeypatch.setattr(path, mock_populate_all_mau)
-    call_command('populate_figures_metrics', '--no-delay', '--mau')
-    assert len(call_list) == 1
-
-
-@pytest.mark.skip('This test does not work')
-def test_mau_no_delay_with_mock(transactional_db):
-    """
-    This would be the preferred test to the above. Acccording to the documentation,
-    this should work, but the mock never gets called, so something is not right
-
-    https://docs.python.org/dev/library/unittest.mock.html#where-to-patch
     """
     path = 'figures.management.commands.populate_figures_metrics.populate_all_mau'
     with mock.patch(path) as mock_populate_all_mau:
-        call_command('populate_figures_metrics', '--no-delay')
+        call_command('populate_figures_metrics', '--no-delay', '--mau')
         mock_populate_all_mau.assert_called()

--- a/tests/views/test_site_monthly_metrics_viewset.py
+++ b/tests/views/test_site_monthly_metrics_viewset.py
@@ -1,0 +1,282 @@
+"""
+Tests Figures site monthly metrics viewset
+"""
+
+from datetime import datetime
+from faker import Faker
+import pytest
+
+import django.contrib.sites.shortcuts
+from django.utils.timezone import utc
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from figures.helpers import is_multisite
+from figures.views import SiteMonthlyMetricsViewSet
+
+from tests.factories import (
+    OrganizationFactory,
+    SiteFactory,
+    UserFactory,
+)
+from tests.helpers import organizations_support_sites
+from tests.views.base import BaseViewTest
+
+fake = Faker()
+
+
+if organizations_support_sites():
+    from tests.factories import UserOrganizationMappingFactory
+
+
+    def map_users_to_org_site(caller, site, users):
+        org = OrganizationFactory(sites=[site])
+        UserOrganizationMappingFactory(user=caller,
+                                       organization=org,
+                                       is_amc_admin=True)
+        [UserOrganizationMappingFactory(user=user,
+                                        organization=org) for user in users]
+        # return created objects that the test will need
+        return caller
+
+
+def generate_date_series(months_back=6, count=20):
+    """
+
+    """
+    start_date = '-{months_back}M'.format(months_back=months_back)
+    date_series = [fake.date_time_between(start_date=start_date,
+                                          end_date='now',
+                                          tzinfo=utc) for i in range(count)]
+    date_series.sort()
+    return date_series
+
+
+@pytest.fixture
+def user_reg_test_data():
+    """
+    Creates a set of users registering over a time period
+    """
+    site = SiteFactory()
+    today = datetime.utcnow().date()
+    months_back = 6
+    users = []
+    dates = generate_date_series(months_back=months_back)
+    assert dates
+    data_spec = zip(dates, range(months_back))
+
+    for reg_date, reg_count in data_spec:
+        users += [UserFactory(date_joined=reg_date) for i in range(reg_count)]
+    return dict(
+        site=site,
+        users=users,
+        dates=dates,
+        months_back=months_back,
+    )
+
+
+@pytest.mark.django_db
+class TestSiteMonthlyMetricsViewSet(BaseViewTest):
+    """
+    TODO:
+    * Refactor tests to use common code
+    """
+    request_path = 'api/site-metrics'
+    view_class = SiteMonthlyMetricsViewSet
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db, settings):
+        if organizations_support_sites():
+            settings.FEATURES['FIGURES_IS_MULTISITE'] = True
+        super(TestSiteMonthlyMetricsViewSet, self).setup(db)
+        self.months_back = 6
+
+    def check_response(self, response, endpoint):
+        assert response.status_code == status.HTTP_200_OK
+        assert endpoint in response.data.keys()
+        current_month_count = response.data[endpoint]['current_month']
+        history_list = response.data[endpoint]['history']
+
+        # check that we have the current month and an element for each prior
+        # month for N months back where N is `months_back`
+        assert len(history_list) == self.months_back + 1
+        for rec in history_list:
+            assert all (key in rec for key in ('period', 'value'))
+        return True
+
+    def run_request(self, endpoint, user_reg_test_data):
+        import pdb; pdb.set_trace()
+
+    @pytest.mark.skip(reason='We need to confirm who is in total registered users')
+    def test_registered_learners(self, monkeypatch, user_reg_test_data):
+        """
+        TODO: create filter and query param for getting unique users who are
+        enrolled in a course and not course staff
+        """
+        pass
+
+    def test_registered_learners(self, monkeypatch, user_reg_test_data):
+        """
+
+        Example response data:
+            {'registered_users': {'current_month': 20,
+            'history': [
+            {'period': '2019/08', 'value': 3},
+            {'period': '2019/09', 'value': 4},
+            {'period': '2019/10', 'value': 7},
+            {'period': '2019/11', 'value': 11},
+            {'period': '2019/12', 'value': 20},
+            {'period': '2020/01', 'value': 20},
+            {'period': '2020/02', 'value': 20}]}}
+        """
+        request_method = 'get'
+        endpoint = 'registered_users'
+        site = user_reg_test_data['site']
+        users = user_reg_test_data['users']
+        dates = user_reg_test_data['dates']
+        months_back = user_reg_test_data['months_back']
+
+        if organizations_support_sites():
+            caller = UserFactory(is_staff=True)
+            map_users_to_org_site(caller=caller, site=site, users=users)
+        else:
+            caller = UserFactory(is_staff=True)
+
+        request = APIRequestFactory().get(self.request_path)
+        request.META['HTTP_HOST'] = site.domain
+        monkeypatch.setattr(django.contrib.sites.shortcuts,
+                            'get_current_site',
+                            lambda req: site)
+        force_authenticate(request, user=caller)
+        view = self.view_class.as_view({request_method: endpoint})
+        response = view(request)
+        assert self.check_response(response=response, endpoint=endpoint)
+
+        # Initially we have a basic structure check
+        # TODO: validate each month's period string and value
+
+    def test_new_users(self, monkeypatch, user_reg_test_data):
+        endpoint = 'new_users'
+        request_method = 'get'
+        site = user_reg_test_data['site']
+        users = user_reg_test_data['users']
+        dates = user_reg_test_data['dates']
+        months_back = user_reg_test_data['months_back']
+
+        if organizations_support_sites():
+            caller = UserFactory(is_staff=True)
+            map_users_to_org_site(caller=caller, site=site, users=users)
+        else:
+            caller = UserFactory(is_staff=True)
+
+        request = APIRequestFactory().get(self.request_path)
+        request.META['HTTP_HOST'] = site.domain
+        monkeypatch.setattr(django.contrib.sites.shortcuts,
+                            'get_current_site',
+                            lambda req: site)
+        force_authenticate(request, user=caller)
+        view = self.view_class.as_view({request_method: endpoint})
+        response = view(request)
+        assert self.check_response(response=response, endpoint=endpoint)
+
+    def test_course_completions(self, monkeypatch, user_reg_test_data):
+        endpoint = 'course_completions'
+        request_method = 'get'
+        site = user_reg_test_data['site']
+        users = user_reg_test_data['users']
+        dates = user_reg_test_data['dates']
+        months_back = user_reg_test_data['months_back']
+
+        if organizations_support_sites():
+            caller = UserFactory(is_staff=True)
+            map_users_to_org_site(caller=caller, site=site, users=users)
+        else:
+            caller = UserFactory(is_staff=True)
+
+        request = APIRequestFactory().get(self.request_path)
+        request.META['HTTP_HOST'] = site.domain
+        monkeypatch.setattr(django.contrib.sites.shortcuts,
+                            'get_current_site',
+                            lambda req: site)
+        force_authenticate(request, user=caller)
+        view = self.view_class.as_view({request_method: endpoint})
+        response = view(request)
+        assert self.check_response(response=response, endpoint=endpoint)
+
+    def test_course_enrollments(self, monkeypatch, user_reg_test_data):
+        endpoint = 'course_enrollments'
+        request_method = 'get'
+        site = user_reg_test_data['site']
+        users = user_reg_test_data['users']
+        dates = user_reg_test_data['dates']
+        months_back = user_reg_test_data['months_back']
+
+        if organizations_support_sites():
+            caller = UserFactory(is_staff=True)
+            map_users_to_org_site(caller=caller, site=site, users=users)
+        else:
+            caller = UserFactory(is_staff=True)
+
+        request = APIRequestFactory().get(self.request_path)
+        request.META['HTTP_HOST'] = site.domain
+        monkeypatch.setattr(django.contrib.sites.shortcuts,
+                            'get_current_site',
+                            lambda req: site)
+        force_authenticate(request, user=caller)
+        view = self.view_class.as_view({request_method: endpoint})
+        response = view(request)
+        assert self.check_response(response=response, endpoint=endpoint)
+
+    def test_site_courses(self, monkeypatch, user_reg_test_data):
+        endpoint = 'site_courses'
+        request_method = 'get'
+        site = user_reg_test_data['site']
+        users = user_reg_test_data['users']
+        dates = user_reg_test_data['dates']
+        months_back = user_reg_test_data['months_back']
+
+        if organizations_support_sites():
+            caller = UserFactory(is_staff=True)
+            map_users_to_org_site(caller=caller, site=site, users=users)
+        else:
+            caller = UserFactory(is_staff=True)
+
+        request = APIRequestFactory().get(self.request_path)
+        request.META['HTTP_HOST'] = site.domain
+        monkeypatch.setattr(django.contrib.sites.shortcuts,
+                            'get_current_site',
+                            lambda req: site)
+        force_authenticate(request, user=caller)
+        view = self.view_class.as_view({request_method: endpoint})
+        response = view(request)
+        assert self.check_response(response=response, endpoint=endpoint)
+
+    def test_active_users(self, monkeypatch, user_reg_test_data):
+        endpoint = 'active_users'
+        request_method = 'get'
+        site = user_reg_test_data['site']
+        users = user_reg_test_data['users']
+        dates = user_reg_test_data['dates']
+        months_back = user_reg_test_data['months_back']
+
+        if organizations_support_sites():
+            caller = UserFactory(is_staff=True)
+            map_users_to_org_site(caller=caller, site=site, users=users)
+        else:
+            caller = UserFactory(is_staff=True)
+
+        request = APIRequestFactory().get(self.request_path)
+        request.META['HTTP_HOST'] = site.domain
+        monkeypatch.setattr(django.contrib.sites.shortcuts,
+                            'get_current_site',
+                            lambda req: site)
+        force_authenticate(request, user=caller)
+        view = self.view_class.as_view({request_method: endpoint})
+        response = view(request)
+        assert self.check_response(response=response, endpoint=endpoint)
+
+
+    @pytest.mark.skip(reason='test this after other module tests pass')
+    def test_run_request(self, monkeypatch, user_reg_test_data):
+        self.run_request(endpoint='registered_users',
+                    user_reg_test_data=user_reg_test_data)


### PR DESCRIPTION
SiteMonthlyMetrics viewset
* Adds new endpoints to retrieve metrics currently in 'GeneralSiteMetricsViewSet'
* endpoints have underscore in url for the custom actions. Deferring
fix. Should create a bug card for this

Other fixes and updates in this commit:

* Fixed figures.metrics naive datetime objects
* Updated figures.metrics to use the User model directly for registered
users (instead of getting from SiteDailyMetrics)