### PR TITLE
Pylint cleanups round 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
 env:
   - TOXENV=py27-hawthorn_community
   - TOXENV=py27-hawthorn_multisite
-  - TOXENV=flake8
   - TOXENV=lint
   - TOXENV=edx_lint_check
 

--- a/figures/admin.py
+++ b/figures/admin.py
@@ -54,7 +54,7 @@ class SiteDailyMetricsAdmin(admin.ModelAdmin):
 class LearnerCourseGradeMetricsAdmin(admin.ModelAdmin):
     """Defines the admin interface for the LearnerCourseGradeMetrics model
     """
-    list_display = ('id', 'date_for',  'site', 'user_link', 'course_id',
+    list_display = ('id', 'date_for', 'site', 'user_link', 'course_id',
                     'progress_percent', 'points_possible', 'points_earned',
                     'sections_worked', 'sections_possible')
     list_filter = (

--- a/figures/compat.py
+++ b/figures/compat.py
@@ -8,7 +8,7 @@ value from openedx.core.release.RELEASE_LINE. This will be the release name as
 a lowercase string, such as 'ginkgo' or 'hawthorn'
 
 '''
-# pylint: disable=ungrouped-imports
+# pylint: disable=ungrouped-imports,useless-suppression
 
 try:
     from openedx.core.release import RELEASE_LINE
@@ -29,7 +29,7 @@ except ImportError:
 
 
 if RELEASE_LINE == 'ginkgo':
-    from certificates.models import GeneratedCertificate  # noqa: F401
+    from certificates.models import GeneratedCertificate  # noqa: F401 pylint: disable=unused-import
 else:
     from lms.djangoapps.certificates.models import GeneratedCertificate  # noqa: F401
 

--- a/figures/mau.py
+++ b/figures/mau.py
@@ -74,7 +74,7 @@ def store_mau_metrics(site, overwrite=False):
                                             month=today.month)
 
     # store site data
-    site_mau_obj, created = SiteMauMetrics.save_metrics(site=site,
+    site_mau_obj, _created = SiteMauMetrics.save_metrics(site=site,
                                                         date_for=today.date(),
                                                         data=dict(mau=site_mau.count()),
                                                         overwrite=overwrite)
@@ -85,7 +85,7 @@ def store_mau_metrics(site, overwrite=False):
             student_modules=course_student_modules,
             year=today.year,
             month=today.month)
-        course_mau_obj, created = CourseMauMetrics.save_metrics(
+        course_mau_obj, _created = CourseMauMetrics.save_metrics(
                 site=site,
                 course_id=str(course_key),
                 date_for=today.date(),

--- a/figures/mau.py
+++ b/figures/mau.py
@@ -75,9 +75,9 @@ def store_mau_metrics(site, overwrite=False):
 
     # store site data
     site_mau_obj, _created = SiteMauMetrics.save_metrics(site=site,
-                                                        date_for=today.date(),
-                                                        data=dict(mau=site_mau.count()),
-                                                        overwrite=overwrite)
+                                                         date_for=today.date(),
+                                                         data=dict(mau=site_mau.count()),
+                                                         overwrite=overwrite)
     course_mau_objects = []
     for course_key in get_course_keys_for_site(site):
         course_student_modules = student_modules.filter(course_id=course_key)

--- a/figures/metrics.py
+++ b/figures/metrics.py
@@ -132,12 +132,11 @@ class LearnerCourseGrades(object):
     def is_section_graded(self, section):
         # just being defensive, might not need to check if
         # all_total exists and if all_total.possible exists
-        if (hasattr(section, 'all_total') and
-                hasattr(section.all_total, 'possible') and
-                section.all_total.possible > 0):
-            return True
-        else:
-            return False
+        return bool(
+            hasattr(section, 'all_total')
+            and hasattr(section.all_total, 'possible')
+            and section.all_total.possible > 0
+        )
 
     def sections(self, only_graded=False, **kwargs):
         """
@@ -210,20 +209,18 @@ class LearnerCourseGrades(object):
             progress_percent=lcg.progress_percent(course_progress_details))
 
 
-"""
-Support methods for Course and Sitewide aggregate metrics
-
-Note the common theme in many of these methods in filtering on a date range
-Also note that some methods have two inner methods. One to retrieve raw data
-from the original model, the other to retrieve from the Figures metrics model
-The purpose of this is to be able to switch back and forth in development
-The metrics model may not be populated in devstack, but we want to exercize
-the code.
-Retrieving from the Figures metrics models should be much faster
-
-We may refactor these into a base class with the contructor params of
-start_date, end_date, site
-"""
+# Support Methods for Both Course and Site-wide Aggregate Metrics
+#
+# Note the common theme in many of these methods in filtering on a date range
+# Also note that some methods have two inner methods. One to retrieve raw data
+# from the original model, the other to retrieve from the Figures metrics model
+# The purpose of this is to be able to switch back and forth in development
+# The metrics model may not be populated in devstack, but we want to exercize
+# the code.
+# Retrieving from the Figures metrics models should be much faster
+#
+# We may refactor these into a base class with the contructor params of
+# start_date, end_date, site
 
 
 def get_active_users_for_time_period(site, start_date, end_date, course_ids=None):

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -206,9 +206,9 @@ def populate_course_mau(site_id, course_id, month_for=None, force_update=False):
     site = Site.objects.get(id=site_id)
     start_time = time.time()
     obj, _created = collect_course_mau(site=site,
-                                      courselike=course_id,
-                                      month_for=month_for,
-                                      overwrite=force_update)
+                                       courselike=course_id,
+                                       month_for=month_for,
+                                       overwrite=force_update)
     if not obj:
         msg = 'populate_course_mau failed for course {course_id}'.format(
             course_id=str(course_id))

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -51,7 +51,7 @@ def populate_single_cdm(course_id, date_for=None, force_update=False):
 
     start_time = time.time()
 
-    cdm_obj, created = CourseDailyMetricsLoader(
+    cdm_obj, _created = CourseDailyMetricsLoader(
         course_id).load(date_for=date_for, force_update=force_update)
     elapsed_time = time.time() - start_time
     logger.info('done. Elapsed time (seconds)={}. cdm_obj={}'.format(
@@ -205,7 +205,7 @@ def populate_course_mau(site_id, course_id, month_for=None, force_update=False):
         month_for = datetime.datetime.utcnow().date()
     site = Site.objects.get(id=site_id)
     start_time = time.time()
-    obj, created = collect_course_mau(site=site,
+    obj, _created = collect_course_mau(site=site,
                                       courselike=course_id,
                                       month_for=month_for,
                                       overwrite=force_update)

--- a/pylintrc
+++ b/pylintrc
@@ -272,7 +272,6 @@ disable =
 	# TODO: Enable those errors incrementally by removing them
 	abstract-method,  # TODO: Remove
 	attribute-defined-outside-init,  # TODO: Remove
-	bad-whitespace,  # TODO: Remove
 	broad-except,  # TODO: Remove
 	empty-docstring,  # TODO: Remove
 	function-redefined,  # TODO: Remove
@@ -281,12 +280,8 @@ disable =
 	len-as-condition,  # TODO: Remove
 	missing-docstring,  # TODO: Remove
 	no-member,  # TODO: Remove
-	pointless-string-statement,  # TODO: Remove
 	redefined-builtin,  # TODO: Remove
-	simplifiable-if-statement,  # TODO: Remove
 	unused-argument,  # TODO: Remove
-	unused-import,  # TODO: Remove
-	unused-variable,  # TODO: Remove
 	# Those are the default we should leave them as-is
 	bad-continuation,
 	invalid-name,
@@ -462,4 +457,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 6b6524f5692ea76a413065c89a2ed471299c7664
+# f3dc59506e5d11198b9e05175386b22b60719575

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -10,7 +10,6 @@ disable =
     # TODO: Enable those errors incrementally by removing them
     abstract-method,  # TODO: Remove
     attribute-defined-outside-init,  # TODO: Remove
-    bad-whitespace,  # TODO: Remove
     broad-except,  # TODO: Remove
     empty-docstring,  # TODO: Remove
     function-redefined,  # TODO: Remove
@@ -19,12 +18,8 @@ disable =
     len-as-condition,  # TODO: Remove
     missing-docstring,  # TODO: Remove
     no-member,  # TODO: Remove
-    pointless-string-statement,  # TODO: Remove
     redefined-builtin,  # TODO: Remove
-    simplifiable-if-statement,  # TODO: Remove
     unused-argument,  # TODO: Remove
-    unused-import,  # TODO: Remove
-    unused-variable,  # TODO: Remove
 
     # Those are the default we should leave them as-is
     bad-continuation,

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist =
 	py27-ginkgo
 	py27-hawthorn_community
 	py27-hawthorn_multisite
-	flake8
 	lint
 	edx_lint_check
 
@@ -44,6 +43,7 @@ basepython=python2
 deps =
 	-r{toxinidir}/devsite/requirements/hawthorn_community.txt
 commands =
+	flake8 figures devsite
 	pylint --load-plugins pylint_django ./figures
 
 [testenv:edx_lint_check]
@@ -61,9 +61,3 @@ deps =
 	-r{toxinidir}/devsite/requirements/hawthorn_community.txt
 commands =
 	edx_lint write pylintrc
-
-[testenv:flake8]
-deps =
-	flake8==3.7.7
-commands =
-	flake8 figures devsite


### PR DESCRIPTION
Enable and fixe the pylint warnings below:

 - bad-whitespace
 - pointless-string-statement
 - simplifiable-if-statement
 - unused-import
 - unused-variable
 - useless-suppression