### PR TITLE
match /figures/ but not /my-figures/

### DIFF
--- a/figures/apps.py
+++ b/figures/apps.py
@@ -45,7 +45,7 @@ class FiguresConfig(AppConfig):
             PluginURLs.CONFIG: {
                 ProjectType.LMS: {
                     PluginURLs.NAMESPACE: u'figures',
-                    PluginURLs.REGEX: u'figures/',
+                    PluginURLs.REGEX: u'^figures/',
                 }
             },
 


### PR DESCRIPTION
A minor fix to avoid having `https://learning.mysite.com/my-precious-figures/` works. I think it's faster for Django performance, but the point is to ensure it doesn't do a false match and introduce a bug in the other lms.

As of Django 3 this PR is not required, but we're not using Django 3 for a while.