### PR TITLE
Refactor figures.permissions

### DIFF
--- a/figures/permissions.py
+++ b/figures/permissions.py
@@ -1,18 +1,19 @@
-'''Provides permissions for Figures views
+"""Provides permissions for Figures views
 
-'''
+"""
 from rest_framework.permissions import BasePermission
 
 import django.contrib.sites.shortcuts
 
-import organizations
+from organizations.models import Organization
+
+try:
+    from organizations.models import UserOrganizationMapping
+except ImportError:
+    pass
 
 import figures.helpers
 import figures.sites
-
-
-class MultipleOrgsPerUserNotSupported(Exception):
-    pass
 
 
 def is_active_staff_or_superuser(request):
@@ -30,25 +31,8 @@ def is_site_admin_user(request):
     * If Figures is running in standalone mode, then the user needs to be staff
       or superuser.
     * If figures is running in multisite mode, then the user needs to belong to
-      the site through the site's organization and have admin permission for
-      that organization or have staff or superuser access.
-
-    ## Multisite implementation
-
-    This initial multisite implementation assumes a user belongs to only one
-    organization in a site. This is represented in the UserOrganizationMapping
-    model in Appsembler's fork of edx-organizations. This model currently does
-    not enforce user-org uniquness. Therefore, multiple records returned is an
-    error and the behavior is undefined. Multiple user organiazation mappings
-    found will raise an exception to prevent returning invalid authorization.
-
-    To support multiple user organization mappings per site, we need to
-    determine the authorization criteria in that environment.
-
-    Note: Depending on community participation, we may make this a pluggable
-    feature but there are other considerations such as future built-in support
-    for site and organization access control in the futire.
-
+      an organizations mapped to the specified site and have `is_amc_admin` set
+      to `True`
 
     ## What this function does
 
@@ -60,27 +44,18 @@ def is_site_admin_user(request):
     has_permission = is_active_staff_or_superuser(request)
     if not has_permission:
         if figures.helpers.is_multisite():
-            current_site = django.contrib.sites.shortcuts.get_current_site(request)
-            orgs = organizations.models.Organization.objects.filter(sites__in=[current_site])
-            # Should just be mappings for organizations in this site
-            # If just one organization in a site, then the queryset returned
-            # should contain just one element
-            uom_qs = organizations.models.UserOrganizationMapping.objects.filter(
-                organization__in=orgs,
-                user=request.user)
-
-            # This is here to Fail because multiple orgs per site is unsupported
-            if uom_qs.count() > 1:
-                raise MultipleOrgsPerUserNotSupported(
-                    'Only one org per user per site is allowed. found {}'.format(
-                        uom_qs.count())
-                    )
-            # Since Tahoe does just one org, we're going to cheat and just look
-            # for the first element
-            if uom_qs and request.user.is_active:
-                has_permission = uom_qs[0].is_amc_admin and uom_qs[0].is_active
+            if request.user.is_active:
+                current_site = django.contrib.sites.shortcuts.get_current_site(request)
+                org_ids = Organization.objects.filter(
+                    sites__in=[current_site]).values_list('id',
+                                                          flat=True)
+                return UserOrganizationMapping.objects.filter(
+                    organization_id__in=org_ids,
+                    user=request.user,
+                    is_active=True,
+                    is_amc_admin=True).exists()
             else:
-                has_permission = False
+                return False
         else:
             has_permission = is_active_staff_or_superuser(request)
     return has_permission


### PR DESCRIPTION
This update simplifies Figures multisite organization admin user check.
The motivation is from Omar Al-Ithawi's PR: https://github.com/appsembler/course-access-groups/pull/12 for the `is_organization_staff` function in `acl_backends.py`