### PR TITLE
Add organizations to INSTALLED_APPS to fix devsite

### DIFF
--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     'django_filters',
     # 'rest_framework.authtoken',
     'webpack_loader',
+    'organizations',
     'devsite',
     'figures',
 


### PR DESCRIPTION
Fix ```RuntimeError: Model class organizations.models.Organization doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.```