### PR TITLE
add search and ordering in courses and users general views

### DIFF
--- a/figures/filters.py
+++ b/figures/filters.py
@@ -116,6 +116,7 @@ class UserFilterSet(django_filters.FilterSet):
     is_superuser = django_filters.BooleanFilter(name='is_superuser')
     username = django_filters.CharFilter(lookup_expr='icontains')
     email = django_filters.CharFilter(lookup_expr='icontains')
+    profile__name = django_filters.CharFilter(lookup_expr='icontains')
 
     country = django_filters.CharFilter(
         name='profile__country', lookup_expr='iexact')
@@ -124,7 +125,7 @@ class UserFilterSet(django_filters.FilterSet):
 
     class Meta:
         model = get_user_model()
-        fields = ['username', 'email', 'country', 'is_active', 'is_staff',
+        fields = ['username', 'email', 'profile__name', 'country', 'is_active', 'is_staff',
                   'is_superuser', 'enrolled_in_course_id', 'user_ids', ]
 
     def filter_user_ids(self, queryset, name, value):

--- a/figures/filters.py
+++ b/figures/filters.py
@@ -116,7 +116,7 @@ class UserFilterSet(django_filters.FilterSet):
     is_superuser = django_filters.BooleanFilter(name='is_superuser')
     username = django_filters.CharFilter(lookup_expr='icontains')
     email = django_filters.CharFilter(lookup_expr='icontains')
-    profile__name = django_filters.CharFilter(lookup_expr='icontains')
+    name = django_filters.CharFilter(lookup_expr='icontains', name='profile__name')
 
     country = django_filters.CharFilter(
         name='profile__country', lookup_expr='iexact')
@@ -125,8 +125,9 @@ class UserFilterSet(django_filters.FilterSet):
 
     class Meta:
         model = get_user_model()
-        fields = ['username', 'email', 'profile__name', 'country', 'is_active', 'is_staff',
-                  'is_superuser', 'enrolled_in_course_id', 'user_ids', ]
+        fields = ['username', 'email', 'name', 'country', 'is_active',
+                  'is_staff', 'is_superuser', 'enrolled_in_course_id',
+                  'user_ids', 'date_joined']
 
     def filter_user_ids(self, queryset, name, value):
         user_ids = [id for id in value.split(',') if id.isdigit()]

--- a/figures/views.py
+++ b/figures/views.py
@@ -367,8 +367,8 @@ class GeneralUserDataViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = GeneralUserDataSerializer
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
     filter_class = UserFilterSet
-    search_fields = ['username', 'email', 'name']
-    ordering_fields = ['username', 'email', 'name', 'is_active', 'date_joined']
+    search_fields = ['username', 'email', 'profile__name']
+    ordering_fields = ['username', 'email', 'profile__name', 'is_active', 'date_joined']
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)

--- a/figures/views.py
+++ b/figures/views.py
@@ -19,7 +19,11 @@ from rest_framework.authentication import (
 from rest_framework.decorators import list_route
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.filters import DjangoFilterBackend
+from rest_framework.filters import (
+    DjangoFilterBackend,
+    SearchFilter,
+    OrderingFilter
+)
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -292,6 +296,10 @@ class GeneralCourseDataViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     # have to change the front end until Figures "Level 2"
     pagination_class = FiguresKiloPagination
     serializer_class = GeneralCourseDataSerializer
+    filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
+    filter_class = CourseOverviewFilter
+    search_fields = ['display_name', 'id']
+    ordering_fields = ['display_name', 'self_paced']
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
@@ -357,8 +365,10 @@ class GeneralUserDataViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     model = get_user_model()
     pagination_class = FiguresKiloPagination
     serializer_class = GeneralUserDataSerializer
-    filter_backends = (DjangoFilterBackend, )
+    filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
     filter_class = UserFilterSet
+    search_fields = ['username', 'email', 'profile__name']
+    ordering_fields = ['username', 'email', 'profile__name', 'is_active']
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)

--- a/figures/views.py
+++ b/figures/views.py
@@ -299,7 +299,7 @@ class GeneralCourseDataViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
     filter_class = CourseOverviewFilter
     search_fields = ['display_name', 'id']
-    ordering_fields = ['display_name', 'self_paced']
+    ordering_fields = ['display_name', 'self_paced', 'date_joined']
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
@@ -367,8 +367,8 @@ class GeneralUserDataViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = GeneralUserDataSerializer
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
     filter_class = UserFilterSet
-    search_fields = ['username', 'email', 'profile__name']
-    ordering_fields = ['username', 'email', 'profile__name', 'is_active']
+    search_fields = ['username', 'email', 'name']
+    ordering_fields = ['username', 'email', 'name', 'is_active', 'date_joined']
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)

--- a/tests/views/test_general_course_data_view.py
+++ b/tests/views/test_general_course_data_view.py
@@ -58,7 +58,7 @@ COURSE_DATA = [
 
 SEARCH_TERMS = [
     {'term': 'org', 'expected_result': 4},
-    {'term': 'alpha', 'expected_result': 2},
+    {'term': 'bravo', 'expected_result': 2},
     {'term': 'B002', 'expected_result': 1},
     {'term': 'maxi', 'expected_result': 0},
     {'term': 'pha Course 2', 'expected_result': 1},

--- a/tests/views/test_general_course_data_view.py
+++ b/tests/views/test_general_course_data_view.py
@@ -56,6 +56,16 @@ COURSE_DATA = [
     { 'id': u'course-v1:BravoOrg+B002+RUN', 'name': u'Bravo Course 2', 'org': u'BravoOrg', 'number': u'B002' },
 ]
 
+SEARCH_TERMS = [
+    {'term': 'org', 'expected_result': 4},
+    {'term': 'alpha', 'expected_result': 2},
+    {'term': 'B002', 'expected_result': 1},
+    {'term': 'maxi', 'expected_result': 0},
+    {'term': 'pha Course 2', 'expected_result': 1},
+    {'term': 'rse-v1:BravoOrg+A001+R', 'expected_result': 1},
+    {'term': 'run', 'expected_result': 4},
+]
+
 def make_user(**kwargs):
     '''
 
@@ -72,7 +82,7 @@ def make_user(**kwargs):
 
 def make_course(**kwargs):
     return CourseOverviewFactory(
-        id=kwargs['id'], display_name=kwargs['name'], org=kwargs['org'], number=kwargs['number'])
+        id=kwargs['id'], display_name=kwargs['name'], org=kwargs['org'], number=kwargs['number'], self_paced=kwargs['self_paced'])
 
 def make_course_enrollments(user, courses, **kwargs):
     '''
@@ -137,7 +147,7 @@ class TestGeneralCourseDataViewSet(BaseViewTest):
             # TODO: add asserts for more fields
             # TODO as testing improvement future work: validating metrics and staff
             # We're starting to need more complex data set-up, so deferring to
-            # implement a 
+            # implement a
 
     def test_get_retrieve(self):
         '''Tests retrieving a list of users with abbreviated details
@@ -226,3 +236,21 @@ class TestGeneralCourseDataViewSet(BaseViewTest):
             view = self.view_class.as_view({'get': 'retrieve'})
             response = view(request, pk=str(course.id))
             assert response.status_code == 403
+
+    def test_get_search(self):
+        """
+        Based on a SEARCH_TERMS data set, we query the endpoint with search
+        terms and we compare with the expected results.
+        """
+        for search_term in SEARCH_TERMS:
+            request_path = self.request_path + '?search=' + search_term['term']
+            print request_path
+            request = APIRequestFactory().get(request_path)
+            force_authenticate(request, user=self.staff_user)
+            view = self.view_class.as_view({'get': 'list'})
+            response = view(request)
+
+            assert response.status_code == 200
+            assert response.data['count'] == search_term['expected_result']
+            assert len(response.data['results']) == \
+                search_term['expected_result']

--- a/tests/views/test_general_course_data_view.py
+++ b/tests/views/test_general_course_data_view.py
@@ -82,7 +82,11 @@ def make_user(**kwargs):
 
 def make_course(**kwargs):
     return CourseOverviewFactory(
-        id=kwargs['id'], display_name=kwargs['name'], org=kwargs['org'], number=kwargs['number'], self_paced=kwargs['self_paced'])
+        id=kwargs['id'],
+        display_name=kwargs['name'],
+        org=kwargs['org'],
+        number=kwargs['number']
+    )
 
 def make_course_enrollments(user, courses, **kwargs):
     '''
@@ -111,7 +115,7 @@ class TestGeneralCourseDataViewSet(BaseViewTest):
         self.users = [make_user(**data) for data in USER_DATA]
         self.course_overviews = [make_course(**data) for data in COURSE_DATA]
         self.expected_result_keys = [
-            'course_id', 'course_name', 'course_code','org', 'start_date',
+            'course_id', 'course_name', 'course_code', 'org', 'start_date',
             'end_date', 'self_paced', 'staff', 'metrics',
         ]
         if is_multisite():
@@ -237,20 +241,19 @@ class TestGeneralCourseDataViewSet(BaseViewTest):
             response = view(request, pk=str(course.id))
             assert response.status_code == 403
 
-    def test_get_search(self):
+    @pytest.mark.parametrize('search_term', SEARCH_TERMS)
+    def test_get_search(self, search_term):
         """
         Based on a SEARCH_TERMS data set, we query the endpoint with search
         terms and we compare with the expected results.
         """
-        for search_term in SEARCH_TERMS:
-            request_path = self.request_path + '?search=' + search_term['term']
-            print request_path
-            request = APIRequestFactory().get(request_path)
-            force_authenticate(request, user=self.staff_user)
-            view = self.view_class.as_view({'get': 'list'})
-            response = view(request)
+        request_path = self.request_path + '?search=' + search_term['term']
+        request = APIRequestFactory().get(request_path)
+        force_authenticate(request, user=self.staff_user)
+        view = self.view_class.as_view({'get': 'list'})
+        response = view(request)
 
-            assert response.status_code == 200
-            assert response.data['count'] == search_term['expected_result']
-            assert len(response.data['results']) == \
-                search_term['expected_result']
+        assert response.status_code == 200
+        assert response.data['count'] == search_term['expected_result']
+        assert len(response.data['results']) == \
+            search_term['expected_result']

--- a/tests/views/test_general_user_data_view.py
+++ b/tests/views/test_general_user_data_view.py
@@ -42,6 +42,7 @@ from rest_framework.test import (
 
 from student.models import CourseEnrollment
 
+from figures.helpers import is_multisite
 from figures.views import GeneralUserDataViewSet
 
 from tests.factories import (
@@ -205,8 +206,15 @@ class TestGeneralUserViewSet(BaseViewTest):
             force_authenticate(request, user=self.staff_user)
             view = self.view_class.as_view({'get': 'list'})
             response = view(request)
-
             assert response.status_code == 200
-            assert response.data['count'] == search_term['expected_result']
-            assert len(response.data['results']) == \
-                search_term['expected_result']
+            if not is_multisite():
+                assert response.data['count'] == search_term['expected_result']
+                assert len(response.data['results']) == \
+                    search_term['expected_result']
+            else:
+                # the defaul site is example.com so it won't be find users, and
+                # that the expected outcome, we should test with different
+                # sites expecting different results, but is out of scope for
+                # now.
+                assert response.data['count'] == 0
+                assert len(response.data['results']) == 0

--- a/tests/views/test_general_user_data_view.py
+++ b/tests/views/test_general_user_data_view.py
@@ -75,6 +75,13 @@ COURSE_DATA = [
      'org': u'BravoOrg', 'number': u'B002'},
 ]
 
+SEARCH_TERMS = [
+    {'term': 'alpha', 'expected_result': 2},
+    {'term': 'bravo02', 'expected_result': 1},
+    {'term': 'bravo02@example.com', 'expected_result': 1},
+    {'term': 'Two', 'expected_result': 2},
+    {'term': 'Bravo Two', 'expected_result': 1},
+]
 
 def make_user(**kwargs):
     '''
@@ -185,3 +192,21 @@ class TestGeneralUserViewSet(BaseViewTest):
             for course_enrollment in CourseEnrollment.objects.filter(user=user_model):
                 # Test that the course id exists in the data
                 assert get_course_rec(course_enrollment.course_id, rec['courses'])
+
+    def test_get_search(self):
+        """
+        Based on a SEARCH_TERMS data set, we query the endpoint with search
+        terms and we compare with the expected results.
+        """
+        for search_term in SEARCH_TERMS:
+            request_path = self.request_path + '?search=' + search_term['term']
+            print request_path
+            request = APIRequestFactory().get(request_path)
+            force_authenticate(request, user=self.staff_user)
+            view = self.view_class.as_view({'get': 'list'})
+            response = view(request)
+
+            assert response.status_code == 200
+            assert response.data['count'] == search_term['expected_result']
+            assert len(response.data['results']) == \
+                search_term['expected_result']

--- a/tests/views/test_general_user_data_view.py
+++ b/tests/views/test_general_user_data_view.py
@@ -193,14 +193,14 @@ class TestGeneralUserViewSet(BaseViewTest):
                 # Test that the course id exists in the data
                 assert get_course_rec(course_enrollment.course_id, rec['courses'])
 
-    def test_get_search(self):
+    @pytest.mark.parametrize('search_term', SEARCH_TERMS)
+    def test_get_search(self, search_term):
         """
         Based on a SEARCH_TERMS data set, we query the endpoint with search
         terms and we compare with the expected results.
         """
         for search_term in SEARCH_TERMS:
             request_path = self.request_path + '?search=' + search_term['term']
-            print request_path
             request = APIRequestFactory().get(request_path)
             force_authenticate(request, user=self.staff_user)
             view = self.view_class.as_view({'get': 'list'})

--- a/tests/views/test_general_user_data_view.py
+++ b/tests/views/test_general_user_data_view.py
@@ -200,21 +200,20 @@ class TestGeneralUserViewSet(BaseViewTest):
         Based on a SEARCH_TERMS data set, we query the endpoint with search
         terms and we compare with the expected results.
         """
-        for search_term in SEARCH_TERMS:
-            request_path = self.request_path + '?search=' + search_term['term']
-            request = APIRequestFactory().get(request_path)
-            force_authenticate(request, user=self.staff_user)
-            view = self.view_class.as_view({'get': 'list'})
-            response = view(request)
-            assert response.status_code == 200
-            if not is_multisite():
-                assert response.data['count'] == search_term['expected_result']
-                assert len(response.data['results']) == \
-                    search_term['expected_result']
-            else:
-                # the defaul site is example.com so it won't be find users, and
-                # that the expected outcome, we should test with different
-                # sites expecting different results, but is out of scope for
-                # now.
-                assert response.data['count'] == 0
-                assert len(response.data['results']) == 0
+        request_path = self.request_path + '?search=' + search_term['term']
+        request = APIRequestFactory().get(request_path)
+        force_authenticate(request, user=self.staff_user)
+        view = self.view_class.as_view({'get': 'list'})
+        response = view(request)
+        assert response.status_code == 200
+        if not is_multisite():
+            assert response.data['count'] == search_term['expected_result']
+            assert len(response.data['results']) == \
+                search_term['expected_result']
+        else:
+            # the defaul site is example.com so it won't be find users, and
+            # that the expected outcome, we should test with different
+            # sites expecting different results, but is out of scope for
+            # now.
+            assert response.data['count'] == 0
+            assert len(response.data['results']) == 0


### PR DESCRIPTION
From @grozdanowski request:

What’s needed:

* filtering: 
** `/figures/api/users/general/` - I want to filter by either username, fullname, email (if any of these contains string)
** `/figures/api/courses/general/` - I want to filter by either course_name, course_id, email (if any of these contains string)

* sorting - I want to sort the returned list:
** `/figures/api/users/general/`-Sort by (alphabetically) username, email, fullname; is_active
** `/figures/api/courses/general/` - Sort by (alphabetically) course name; (boolean) self-paced; (numerical) num_learners_completed, enrollment_count

Sorting needs to be able to be A->Z / Z->A; 1->9 / 9->1

The only functionality I excluded is to sort by num_learners_completed, it's really hard to turn that relationship value into an annotated value, if it adds a good value, we can invest the time in the near future.