### PR TITLE
Check for and fix 5 pylint warnings (round 3)

### DIFF
--- a/figures/filters.py
+++ b/figures/filters.py
@@ -83,7 +83,7 @@ class CourseEnrollmentFilter(django_filters.FilterSet):
     course_id = char_method_filter(method='filter_course_id')
     is_active = django_filters.BooleanFilter(name='is_active',)
 
-    def filter_course_id(self, queryset, name, value):
+    def filter_course_id(self, queryset, name, value):  # pylint: disable=unused-argument
         '''
 
         This method converts the course id string to a CourseLocator object
@@ -127,11 +127,12 @@ class UserFilterSet(django_filters.FilterSet):
         fields = ['username', 'email', 'country', 'is_active', 'is_staff',
                   'is_superuser', 'enrolled_in_course_id', 'user_ids', ]
 
-    def filter_user_ids(self, queryset, name, value):
-        user_ids = [id for id in value.split(',') if id.isdigit()]
+    def filter_user_ids(self, queryset, name, value):  # pylint: disable=unused-argument
+        user_ids = [user_id for user_id in value.split(',') if user_id.isdigit()]
         return queryset.filter(id__in=user_ids)
 
-    def filter_enrolled_in_course_id(self, queryset, name, value):
+    def filter_enrolled_in_course_id(self, queryset,
+                                     name, value):  # pylint: disable=unused-argument
         '''
 
         This method converts the course id string to a CourseLocator object

--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -116,9 +116,8 @@ def days_in_month(month_for):
 
 
 # TODO: Consider changing name to 'months_back_iterator' or similar
-# TODO: implement or removed include_month_for
-def previous_months_iterator(month_for, months_back, include_month_for=False):
-    '''Iterator returns a year,month tulbe for n months including the month_for
+def previous_months_iterator(month_for, months_back):
+    '''Iterator returns a year,month tuple for n months including the month_for
 
     month_for is either a date, datetime, or tuple with year and month
     months back is the number of months to iterate

--- a/figures/metrics.py
+++ b/figures/metrics.py
@@ -53,10 +53,10 @@ import figures.sites
 #
 
 
-def period_str(month_tuple, format='%Y/%m'):
+def period_str(month_tuple, fmt='%Y/%m'):
     """Returns display date for the given month tuple containing year, month, day
     """
-    return datetime.date(*month_tuple).strftime(format)
+    return datetime.date(*month_tuple).strftime(fmt)
 
 
 #
@@ -91,7 +91,7 @@ class LearnerCourseGrades(object):
     TODO: Make convenience method to instantiate from a GeneratedCertificate
     """
 
-    def __init__(self, user_id, course_id, **kwargs):
+    def __init__(self, user_id, course_id, **_kwargs):
         """
 
         If figures.compat.course_grade is unable to retrieve the course blocks,
@@ -139,7 +139,7 @@ class LearnerCourseGrades(object):
             and section.all_total.possible > 0
         )
 
-    def sections(self, only_graded=False, **kwargs):
+    def sections(self, only_graded=False, **_kwargs):
         """
         yields objects of type:
             lms.djangoapps.grades.new.subsection_grade.SubsectionGrade
@@ -284,7 +284,8 @@ def get_total_site_users_for_time_period(site, start_date, end_date, **kwargs):
         return calc_from_user_model()
 
 
-def get_total_site_users_joined_for_time_period(site, start_date, end_date, course_ids=None):
+def get_total_site_users_joined_for_time_period(site, start_date, end_date,
+                                                course_ids=None):  # pylint: disable=unused-argument
     """returns the number of new enrollments for the time period
 
     NOTE: Untested and not yet used in the general site metrics, but we'll want to add it
@@ -304,7 +305,8 @@ def get_total_site_users_joined_for_time_period(site, start_date, end_date, cour
     return calc_from_user_model()
 
 
-def get_total_enrollments_for_time_period(site, start_date, end_date, course_ids=None):
+def get_total_enrollments_for_time_period(site, start_date, end_date,
+                                          course_ids=None):  # pylint: disable=unused-argument
     """Returns the maximum number of enrollments
 
     This returns the count of unique enrollments, not unique learners
@@ -322,8 +324,7 @@ def get_total_enrollments_for_time_period(site, start_date, end_date, course_ids
         return 0
 
 
-def get_total_site_courses_for_time_period(site, start_date, end_date,
-                                           course_ids=None, **kwargs):
+def get_total_site_courses_for_time_period(site, start_date, end_date, **kwargs):
     """
     Potential fix:
     get unique course ids from CourseEnrollment
@@ -357,7 +358,7 @@ def get_total_site_courses_for_time_period(site, start_date, end_date,
         return calc_from_site_daily_metrics()
 
 
-def get_total_course_completions_for_time_period(site, start_date, end_date, course_ids=None):
+def get_total_course_completions_for_time_period(site, start_date, end_date):
     """
     This metric is not currently captured in SiteDailyMetrics, so retrieving from
     course dailies instead
@@ -451,7 +452,7 @@ def get_course_num_learners_completed_for_time_period(site, start_date, end_date
 
 
 def get_monthly_history_metric(func, site, date_for, months_back,
-                               include_current_in_history=True):
+                               include_current_in_history=True):  # pylint: disable=unused-argument
     """Convenience method to retrieve current and historic data
 
     Convenience function to populate monthly metrics data with history. Purpose
@@ -498,7 +499,7 @@ def get_monthly_history_metric(func, site, date_for, months_back,
         history=history,)
 
 
-def get_current_month_site_metrics(site, **kwargs):
+def get_current_month_site_metrics(site, **_kwargs):
     """
     TODO: put the metric names and functions in a dict and iterate. This then
     will let up dynamically retrieve fields for the monthly metrics this function

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -111,11 +111,11 @@ def get_average_progress(course_id, date_for, course_enrollments):
                 course_progress_details=None)
         if course_progress:
             progress.append(course_progress)
-    if len(progress):
+
+    if progress:
         progress_percent = [rec['progress_percent'] for rec in progress]
         average_progress = float(sum(progress_percent)) / float(len(progress_percent))
         average_progress = float(Decimal(average_progress).quantize(Decimal('.00')))
-
     else:
         average_progress = 0.0
 
@@ -215,7 +215,7 @@ class CourseDailyMetricsExtractor(object):
     BUT, we will then need to find a transform
     """
 
-    def extract(self, course_id, date_for=None, **kwargs):
+    def extract(self, course_id, date_for=None, **_kwargs):
         """
             defaults = dict(
                 enrollment_count=data['enrollment_count'],
@@ -301,7 +301,7 @@ class CourseDailyMetricsLoader(object):
         cdm.clean_fields()
         return (cdm, created,)
 
-    def load(self, date_for=None, force_update=False, **kwargs):
+    def load(self, date_for=None, force_update=False, **_kwargs):
         """
         TODO: clean up how we do this. We want to be able to call the loader
         with an existing data set (not having to call the extractor) but we

--- a/figures/pipeline/site_daily_metrics.py
+++ b/figures/pipeline/site_daily_metrics.py
@@ -87,7 +87,7 @@ def get_previous_cumulative_active_user_count(site, date_for):
         return 0
 
 
-def get_total_enrollment_count(site, date_for, course_ids=None):
+def get_total_enrollment_count(site, date_for, course_ids=None):  # pylint: disable=unused-argument
     '''Returns the total enrollments across all courses for the site
     It does not return unique learners
     '''
@@ -110,7 +110,7 @@ class SiteDailyMetricsExtractor(object):
     def __init__(self):
         pass
 
-    def extract(self, site, date_for=None, **kwargs):
+    def extract(self, site, date_for=None, **kwargs):  # pylint: disable=unused-argument
         '''
         We get the count from the User model since there can be registered users
         who have not enrolled.
@@ -147,7 +147,7 @@ class SiteDailyMetricsLoader(object):
     def __init__(self, extractor=None):
         self.extractor = extractor or SiteDailyMetricsExtractor()
 
-    def load(self, site, date_for=None, force_update=False, **kwargs):
+    def load(self, site, date_for=None, force_update=False, **_kwargs):
         '''
         Architectural note:
         Initially, we're going to be explicit, requiring callers to specify the

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -253,7 +253,7 @@ class GeneralCourseDataSerializer(serializers.Serializer):
         ]
 
     """
-    # site = serializers.SerializerMethodField()
+    site = None
     course_id = serializers.CharField(source='id', read_only=True)
     course_name = serializers.CharField(
         source='display_name_with_default_escaped', read_only=True)
@@ -344,6 +344,7 @@ class CourseDetailsSerializer(serializers.ModelSerializer):
     Need to ask edX team why CourseEnrollment doesn't have a foreign key
     relationship to CourseOverview
     """
+    site = None
     course_id = serializers.CharField(source='id', read_only=True)
     course_name = serializers.CharField(
         source='display_name_with_default_escaped', read_only=True)
@@ -449,23 +450,23 @@ class GeneralSiteMetricsSerializer(serializers.Serializer):
     total_course_enrollments = serializers.SerializerMethodField()
     total_course_completions = serializers.SerializerMethodField()
 
-    def get_monthly_active_users(self, obj):
+    def get_monthly_active_users(self, _obj):
         return dict(
         )
 
-    def get_total_site_users(self, obj):
+    def get_total_site_users(self, _obj):
         return dict(
         )
 
-    def get_total_site_courses(self, obj):
+    def get_total_site_courses(self, _obj):
         return dict(
         )
 
-    def get_total_course_enrollments(self, obj):
+    def get_total_course_enrollments(self, _obj):
         return dict(
         )
 
-    def get_total_course_completions(self, obj):
+    def get_total_course_completions(self, _obj):
         return dict(
         )
 

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -73,6 +73,8 @@ def default_site():
     if getattr(settings, 'SITE_ID', ''):
         return Site.objects.get(pk=settings.SITE_ID)
 
+    return None
+
 
 def get_site_for_course(course_id):
     """

--- a/figures/views.py
+++ b/figures/views.py
@@ -268,7 +268,7 @@ class GeneralSiteMetricsView(CommonAuthMixin, APIView):
         '''
         return metrics.get_monthly_site_metrics
 
-    def get(self, request, format=None):
+    def get(self, request, format=None):  # pylint: disable=redefined-builtin
         '''
         Does not yet support multi-tenancy
         '''

--- a/pylintrc
+++ b/pylintrc
@@ -271,17 +271,12 @@ enable =
 disable = 
 	# TODO: Enable those errors incrementally by removing them
 	abstract-method,  # TODO: Remove
-	attribute-defined-outside-init,  # TODO: Remove
 	broad-except,  # TODO: Remove
 	empty-docstring,  # TODO: Remove
 	function-redefined,  # TODO: Remove
 	import-error,  # TODO: Remove
-	inconsistent-return-statements,  # TODO: Remove
-	len-as-condition,  # TODO: Remove
 	missing-docstring,  # TODO: Remove
 	no-member,  # TODO: Remove
-	redefined-builtin,  # TODO: Remove
-	unused-argument,  # TODO: Remove
 	# Those are the default we should leave them as-is
 	bad-continuation,
 	invalid-name,
@@ -457,4 +452,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# f3dc59506e5d11198b9e05175386b22b60719575
+# 92b91929ba5d9ead70bb87b757d6f1df9a21a86e

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -9,17 +9,12 @@ load-plugins = edx_lint.pylint,pylint_django,pylint_celery
 disable =
     # TODO: Enable those errors incrementally by removing them
     abstract-method,  # TODO: Remove
-    attribute-defined-outside-init,  # TODO: Remove
     broad-except,  # TODO: Remove
     empty-docstring,  # TODO: Remove
     function-redefined,  # TODO: Remove
     import-error,  # TODO: Remove
-    inconsistent-return-statements,  # TODO: Remove
-    len-as-condition,  # TODO: Remove
     missing-docstring,  # TODO: Remove
     no-member,  # TODO: Remove
-    redefined-builtin,  # TODO: Remove
-    unused-argument,  # TODO: Remove
 
     # Those are the default we should leave them as-is
     bad-continuation,


### PR DESCRIPTION
Fixing the following errors:

 - `attribute-defined-outside-init`: Initialize the attribute with `None` e.g. `site = None`
 - `inconsistent-return-statements`: Make it consistent by `return None`
 - `len-as-condition`: Simply removing `len()` fixes the issue
 - `redefined-builtin`: Renaming a couple of builtins like `id -> user_id` and `format -> fmt`
 - `unused-argument`: Remove the argument, prefix it with underscore e.g. `_kwargs` or use a pylint disable flag