### PR TITLE
Optimise api calls

### DIFF
--- a/frontend/src/components/inputs/AutoCompleteCourseSelect.js
+++ b/frontend/src/components/inputs/AutoCompleteCourseSelect.js
@@ -83,12 +83,6 @@ class AutoCompleteCourseSelect extends Component {
 
   componentWillMount() {
     this.timer = null;
-    fetch((apiConfig.coursesGeneral), { credentials: "same-origin" })
-      .then(response => response.json())
-      .then(json => this.setState({
-        suggestions: json['results'],
-      })
-    )
   }
 
   render() {

--- a/frontend/src/components/inputs/AutoCompleteUserSelect.js
+++ b/frontend/src/components/inputs/AutoCompleteUserSelect.js
@@ -83,12 +83,6 @@ class AutoCompleteUserSelect extends Component {
 
   componentWillMount() {
     this.timer = null;
-    fetch((apiConfig.figuresUsersIndexApi), { credentials: "same-origin" })
-      .then(response => response.json())
-      .then(json => this.setState({
-        suggestions: json['results'],
-      })
-    )
   }
 
   render() {

--- a/frontend/src/views/DashboardContent.js
+++ b/frontend/src/views/DashboardContent.js
@@ -2,13 +2,11 @@ import React, { Component } from 'react';
 import { NavLink } from 'react-router-dom';
 import classNames from 'classnames/bind';
 import { connect } from 'react-redux';
-import { trackPromise } from 'react-promise-tracker';
 import Immutable from 'immutable';
 import styles from './_dashboard-content.scss';
 import HeaderAreaLayout from 'base/components/layout/HeaderAreaLayout';
 import HeaderContentMaus from 'base/components/header-views/header-content-maus/HeaderContentMaus';
 import BaseStatCard from 'base/components/stat-cards/BaseStatCard';
-import apiConfig from 'base/apiConfig';
 
 let cx = classNames.bind(styles);
 
@@ -18,23 +16,8 @@ class DashboardContent extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      coursesDetailed: Immutable.List(),
+
     };
-    this.fetchCoursesList = this.fetchCoursesList.bind(this);
-  }
-
-  fetchCoursesList = () => {
-    trackPromise(
-      fetch(apiConfig.coursesDetailed, { credentials: "same-origin" })
-        .then(response => response.json())
-        .then(json => this.setState({
-          coursesDetailed: Immutable.fromJS(json['results'])
-        }))
-    )
-  }
-
-  componentDidMount() {
-    this.fetchCoursesList();
   }
 
   render() {


### PR DESCRIPTION
This PR optimises the load times of the Figures app by:
- removing the call to course details API on Dashboard loading (that became obsolete)
- removing the initial call to pre-populate the dropdowns for Course and User header autocompletes. That is not essential (low UX impact estimated) and shaves a lot off initial load times.