### PR TITLE
Frontend bugfixes

### DIFF
--- a/frontend/src/views/DashboardContent.js
+++ b/frontend/src/views/DashboardContent.js
@@ -38,7 +38,7 @@ class DashboardContent extends Component {
           <BaseStatCard
             mainValue={this.props.generalData.getIn(['newUsers', 'current_month'], 0)}
             valueHistory={this.props.generalData.getIn(['newUsers', 'history'], [])}
-            cardTitle='Registered learners'
+            cardTitle='New learners'
           />
           <BaseStatCard
             mainValue={this.props.generalData.getIn(['courseEnrollments', 'current_month'], 0)}

--- a/frontend/src/views/MauDetailsContent.js
+++ b/frontend/src/views/MauDetailsContent.js
@@ -11,15 +11,15 @@ let cx = classNames.bind(styles);
 class MauDetailsContent extends Component {
 
   render() {
-    let previousValue = 0;
+    let previousValue = undefined;
     const mausRender = this.props.mauHistory.map((period, index) => {
-      const difference = period.value - previousValue;
+      const difference = previousValue ? (period.value - previousValue) : 'N/A';
       previousValue = period.value;
       return (
         <li key={index} className={styles['content-row']}>
           <span className={styles['period']}>{period.period}</span>
           <span className={styles['mau-count']}>{period.value}</span>
-          <span className={cx({ 'difference': true, 'positive': (difference > 0), 'negative': (difference < 0)})}>{(difference > 0) ? "+" : ""}{difference}</span>
+          <span className={cx({ 'difference': true, 'positive': ((difference > 0) || (difference === undefined)), 'negative': (difference < 0)})}>{(difference > 0) ? "+" : ""}{difference}</span>
         </li>
       )
     });
@@ -43,7 +43,7 @@ class MauDetailsContent extends Component {
                   <span className={styles['mau-count']}>Monthly active users</span>
                   <span className={styles['difference']}>Difference vs. previous period</span>
                 </li>
-                {mausRender}
+                {mausRender.reverse()}
               </ul>
             </div>
           </section>


### PR DESCRIPTION
This PR addresses three issues:

- on the Dashboard we had two metrics with the same label. The second one was mislabeled and is now labeled correctly ("Registered learners" -> "New learners")
- MAU history list was showing in order that is opposite from the logical one. Now it is reversed.
- When a previous month didn't exist in MAU history list, it would count the increase as if the previous month had a value of 0 (zero). Now it says "N/A".