### PR TITLE
Style fixes and label name change

### DIFF
--- a/frontend/src/sass/base/_base-overrides.scss
+++ b/frontend/src/sass/base/_base-overrides.scss
@@ -20,10 +20,16 @@
 			text-shadow: none;
 			border: none;
 			outline: none;
+
+			&:hover {
+				background-image: none;
+				background-color: unset;
+			}
 		}
 
 		input[type="submit"]:active:not(:disabled), input[type="submit"]:focus:not(:disabled), input[type="button"]:active:not(:disabled), input[type="button"]:focus:not(:disabled), button:active:not(:disabled), button:focus:not(:disabled), .button:active:not(:disabled), button {
 		  box-shadow: none;
+			letter-spacing: normal;
 		}
 	}
 }

--- a/frontend/src/sass/base/_variables.scss
+++ b/frontend/src/sass/base/_variables.scss
@@ -4,6 +4,7 @@ $rem-base-size: 10 !default;
 $base-font-size: calcRem(14) !default;
 $max-grid-width: calcRem(1180);
 $mobile-breakpoint: calcRem(420);
+$half-screen-breakpoint: calcRem(639);
 $tablet-breakpoint: calcRem(1020);
 
 $font-family: 'Open Sans', sans-serif;

--- a/frontend/src/views/CoursesList.js
+++ b/frontend/src/views/CoursesList.js
@@ -116,27 +116,69 @@ class CoursesList extends Component {
       return (
         <li key={course['id']} className={styles['course-list-item']}>
           <div className={styles['course-name']}>
-            <Link
-              className={styles['course-name-link']}
-              to={'/figures/course/' + course['course_id']}
-            >
-              {course['course_name']}
-            </Link>
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Course name:
+              </div>
+              <div className={styles['mobile-value']}>
+                <Link
+                  className={styles['course-name-link']}
+                  to={'/figures/course/' + course['course_id']}
+                >
+                  {course['course_name']}
+                </Link>
+              </div>
+            </div>
           </div>
           <div className={styles['course-id']}>
-            {course['course_id']}
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Course ID:
+              </div>
+              <div className={styles['mobile-value']}>
+                {course['course_id']}
+              </div>
+            </div>
           </div>
           <div className={styles['start-date']}>
-            {parseCourseDate(course['start_date'])}
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Course start:
+              </div>
+              <div className={styles['mobile-value']}>
+                {parseCourseDate(course['start_date'])}
+              </div>
+            </div>
           </div>
           <div className={styles['self-paced']}>
-            {course['self_paced'] ? <FontAwesomeIcon icon={faCheck} className={styles['checkmark-icon']} /> : '-'}
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Self paced:
+              </div>
+              <div className={styles['mobile-value']}>
+                {course['self_paced'] ? <FontAwesomeIcon icon={faCheck} className={styles['checkmark-icon']} /> : '-'}
+              </div>
+            </div>
           </div>
           <div className={styles['enrolments']}>
-            {course['metrics']['enrollment_count']}
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Enrolments:
+              </div>
+              <div className={styles['mobile-value']}>
+                {course['metrics']['enrollment_count']}
+              </div>
+            </div>
           </div>
           <div className={styles['completions']}>
-            {course['metrics']['num_learners_completed']}
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Completions:
+              </div>
+              <div className={styles['mobile-value']}>
+                {course['metrics']['num_learners_completed']}
+              </div>
+            </div>
           </div>
           <div className={styles['action-container']}>
             <Link

--- a/frontend/src/views/SingleUserContent.js
+++ b/frontend/src/views/SingleUserContent.js
@@ -91,8 +91,8 @@ class SingleUserContent extends Component {
                 <span className={styles['value']}>{dateJoined.toUTCString()}</span>
               </li>
               <li>
-                <span className={styles['label']}>Is active:</span>
-                <span className={styles['value']}>{this.state.userData.getIn(['is_active'], false) ? 'Active user' : 'User inactive'}</span>
+                <span className={styles['label']}>Account activated:</span>
+                <span className={styles['value']}>{this.state.userData.getIn(['is_active'], false) ? 'Account activated' : 'Not activated'}</span>
               </li>
               <li>
                 <span className={styles['label']}>Courses enrolled:</span>

--- a/frontend/src/views/UsersList.js
+++ b/frontend/src/views/UsersList.js
@@ -99,24 +99,59 @@ class UsersList extends Component {
       return (
         <li key={user['id']} className={styles['user-list-item']}>
           <div className={styles['user-fullname']}>
-            <Link
-              className={styles['user-fullname-link']}
-              to={'/figures/user/' + user['id']}
-            >
-              {user['fullname']}
-            </Link>
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Full name:
+              </div>
+              <div className={styles['mobile-value']}>
+                <Link
+                  className={styles['user-fullname-link']}
+                  to={'/figures/user/' + user['id']}
+                >
+                  {user['fullname']}
+                </Link>
+              </div>
+            </div>
           </div>
           <div className={styles['username']}>
-            {user['username']}
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Username:
+              </div>
+              <div className={styles['mobile-value']}>
+                {user['username']}
+              </div>
+            </div>
           </div>
           <div className={styles['is-active']}>
-            {user['is_active'] ? <FontAwesomeIcon icon={faCheck} className={styles['checkmark-icon']} /> : '-'}
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Is activated:
+              </div>
+              <div className={styles['mobile-value']}>
+                {user['is_active'] ? <FontAwesomeIcon icon={faCheck} className={styles['checkmark-icon']} /> : '-'}
+              </div>
+            </div>
           </div>
           <div className={styles['date-joined']}>
-            {user['date_joined']}
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Date joined:
+              </div>
+              <div className={styles['mobile-value']}>
+                {user['date_joined']}
+              </div>
+            </div>
           </div>
           <div className={styles['number-of-courses']}>
-            {user['courses'].length}
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                No. of courses:
+              </div>
+              <div className={styles['mobile-value']}>
+                {user['courses'].length}
+              </div>
+            </div>
           </div>
           <div className={styles['action-container']}>
             <Link
@@ -190,7 +225,7 @@ class UsersList extends Component {
                   onClick={() => (this.state.ordering !== 'is_active') ? this.setOrdering('is_active') : this.setOrdering('-is_active')}
                 >
                   <span>
-                    Is user active
+                    Is activated
                   </span>
                   {(this.state.ordering === 'is_active') ? (
                     <FontAwesomeIcon icon={faAngleDoubleUp} />

--- a/frontend/src/views/_courses-list-content.scss
+++ b/frontend/src/views/_courses-list-content.scss
@@ -22,6 +22,11 @@
   font-size: calcRem(14);
   align-items: center;
 
+  @media (max-width: $half-screen-breakpoint) {
+    grid-template-columns: 1fr;
+    grid-row-gap: calcRem(15);
+  }
+
   &.list-header {
     font-size: calcRem(12);
   }
@@ -56,10 +61,19 @@
 
   .start-date, .self-paced, .enrolments, .completions {
     text-align: center;
+
+    @media (max-width: $half-screen-breakpoint) {
+      text-align: left;
+    }
   }
 
   .action-container {
     text-align: right;
+
+    @media (max-width: $half-screen-breakpoint) {
+      text-align: left;
+      padding-top: calcRem(15);
+    }
   }
 
   .course-action {
@@ -78,5 +92,35 @@
       color: #fff;
       background: $primary-color;
     }
+
+    @media (max-width: $half-screen-breakpoint) {
+      display: inline-block;
+      min-width: calcRem(200);
+      text-align: center;
+    }
+  }
+}
+
+.in-cell-label-value {
+  display: flex;
+  align-items: baseline;
+
+  .mobile-label {
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: calcRem(90);
+    margin-right: calcRem(15);
+    font-size: calcRem(12);
+    color: #666;
+
+    @media (min-width: $half-screen-breakpoint) {
+      display: none;
+    }
+  }
+
+  .mobile-value {
+    flex-grow: 1;
+    flex-shrink: 1;
+    width: 100%;
   }
 }

--- a/frontend/src/views/_users-list-content.scss
+++ b/frontend/src/views/_users-list-content.scss
@@ -22,6 +22,11 @@
   font-size: calcRem(14);
   align-items: center;
 
+  @media (max-width: $half-screen-breakpoint) {
+    grid-template-columns: 1fr;
+    grid-row-gap: calcRem(15);
+  }
+
   &.list-header {
     font-size: calcRem(12);
   }
@@ -56,10 +61,19 @@
 
   .is-active, .number-of-courses, .date-joined {
     text-align: center;
+
+    @media (max-width: $half-screen-breakpoint) {
+      text-align: left;
+    }
   }
 
   .action-container {
     text-align: right;
+
+    @media (max-width: $half-screen-breakpoint) {
+      text-align: left;
+      padding-top: calcRem(15);
+    }
   }
 
   .user-action {
@@ -78,5 +92,35 @@
       color: #fff;
       background: $primary-color;
     }
+
+    @media (max-width: $half-screen-breakpoint) {
+      display: inline-block;
+      min-width: calcRem(200);
+      text-align: center;
+    }
+  }
+}
+
+.in-cell-label-value {
+  display: flex;
+  align-items: baseline;
+
+  .mobile-label {
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: calcRem(90);
+    margin-right: calcRem(15);
+    font-size: calcRem(12);
+    color: #666;
+
+    @media (min-width: $half-screen-breakpoint) {
+      display: none;
+    }
+  }
+
+  .mobile-value {
+    flex-grow: 1;
+    flex-shrink: 1;
+    width: 100%;
   }
 }


### PR DESCRIPTION
This PR addresses multiple issues:

- in a list (Courses, Users) the list header buttons had weird hover styles and weird letter spacing. This was traced to super intrusive Open edX styles and has been dealt with.
- when screen width is reduced, list columns layout would start breaking. We added improved responsive behaviour (see below).
- users have a "is_active" flag that was being mistranslated to the frontend as "Is user active" which gets confused with MAUs. It actually reflects whether the account was activated upon registration. This is now reflected in the UI.

![figures-responsive](https://user-images.githubusercontent.com/10602234/79485212-231d1b00-8015-11ea-867a-40dc0ca250c9.gif)
