### PR TITLE
Added Django Debug Toolbar to the devsite

### DIFF
--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     'django_countries',
     'django_filters',
     # 'rest_framework.authtoken',
+    'debug_toolbar',
     'webpack_loader',
     'organizations',
     'devsite',
@@ -84,6 +85,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 
 ROOT_URLCONF = 'devsite.urls'
@@ -183,3 +185,8 @@ ENV_TOKENS = {}
 
 update_webpack_loader(WEBPACK_LOADER, ENV_TOKENS)
 update_celerybeat_schedule(CELERYBEAT_SCHEDULE, ENV_TOKENS)
+
+# Used by Django Debug Toolbar
+INTERNAL_IPS = [
+    '127.0.0.1'
+]

--- a/devsite/devsite/urls.py
+++ b/devsite/devsite/urls.py
@@ -4,6 +4,7 @@ URL patterns includes for Figures devsite
 
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.conf import settings
 from django.views.generic import TemplateView
 
 urlpatterns = [
@@ -12,3 +13,9 @@ urlpatterns = [
     url(r'^accounts/', include('django.contrib.auth.urls')),
     url(r'^figures/', include('figures.urls', namespace='figures')),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]

--- a/devsite/requirements/ginkgo.txt
+++ b/devsite/requirements/ginkgo.txt
@@ -53,6 +53,14 @@ edx-opaque-keys==0.4
 #edx-drf-extensions==1.2.2
 edx-organizations==0.4.4
 
+
+##
+## Devsite 
+##
+
+django-debug-toolbar==1.11
+
+
 ##
 ## Pytest dependencies
 ##

--- a/devsite/requirements/hawthorn_community.txt
+++ b/devsite/requirements/hawthorn_community.txt
@@ -52,6 +52,12 @@ edx-opaque-keys==0.4.4
 
 edx-organizations==0.4.10
 
+##
+## Devsite 
+##
+
+django-debug-toolbar==1.11
+
 
 ##
 ## Test dependencies

--- a/devsite/requirements/hawthorn_multisite.txt
+++ b/devsite/requirements/hawthorn_multisite.txt
@@ -56,6 +56,13 @@ git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4
 
 
 ##
+## Devsite 
+##
+
+django-debug-toolbar==1.11
+
+
+##
 ## Test dependencies
 ##
 


### PR DESCRIPTION
This is mostly helpful to help debug slow queries and could be helpful for other issues too.

Please try it out in your dev environment

https://github.com/jazzband/django-debug-toolbar


There is one pretty annoying thing that I'm still investigating by digging into the debug toolbar source code. The SQL history just keeps growing and growing and there is not a clear way to reset/clear the SQL history. 