### PR TITLE
Update Site MAU metrics pipeline code

### DIFF
--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -31,7 +31,8 @@ def backfill_monthly_metrics_for_site(site, overwrite=False):
     for dt in rrule(freq=MONTHLY, dtstart=start_month, until=last_month):
         obj, created = fill_month(site=site,
                                   month_for=dt,
-                                  student_modules=site_sm)
+                                  student_modules=site_sm,
+                                  overwrite=overwrite)
         backfilled.append(dict(obj=obj, created=created, dt=dt))
 
     return backfilled

--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -9,16 +9,12 @@ from dateutil.relativedelta import relativedelta
 
 from django.utils.timezone import utc
 
-from figures.mau import get_mau_from_student_modules
-from figures.models import SiteMonthlyMetrics
 from figures.sites import get_student_modules_for_site
+from figures.pipeline.site_monthly_metrics import fill_month
 
 
 def backfill_monthly_metrics_for_site(site, overwrite=False):
-    """Quick hack function to backfill all historical site metrics for the site
-
-    We are a bit verbose with the output to help testing and validation since
-    this function was quickly put together
+    """Backfill all historical site metrics for the specified site
     """
     site_sm = get_student_modules_for_site(site)
     if not site_sm:
@@ -26,34 +22,16 @@ def backfill_monthly_metrics_for_site(site, overwrite=False):
 
     first_created = site_sm.order_by('created').first().created
 
-    # We do this because there _might_ be a bug in `dateutil.rrule`. It was
-    # skipping over February when we used the `created` field directly for the
-    # start_month variable
     start_month = datetime(year=first_created.year,
                            month=first_created.month,
-                           day=1).replace(tzinfo=utc)
+                           day=1,
+                           tzinfo=utc)
     last_month = datetime.utcnow().replace(tzinfo=utc) - relativedelta(months=1)
     backfilled = []
     for dt in rrule(freq=MONTHLY, dtstart=start_month, until=last_month):
-        mau = get_mau_from_student_modules(student_modules=site_sm,
-                                           year=dt.year,
-                                           month=dt.month)
-        month_sm = site_sm.filter(modified__year=dt.year, modified__month=dt.month)
-        month_learners = month_sm.values_list('student__id', flat=True).distinct()
-
-        obj, created = SiteMonthlyMetrics.add_month(
-            site=site,
-            year=dt.year,
-            month=dt.month,
-            active_user_count=month_learners.count(),
-            overwrite=overwrite)
-
-        backfill_rec = dict(
-            obj=obj,
-            created=created,
-            dt=dt,
-            mau=mau)
-        backfilled.append(backfill_rec)
+        obj, created = fill_month(site=site,
+                                  month_for=dt,
+                                  student_modules=site_sm)
+        backfilled.append(dict(obj=obj, created=created, dt=dt))
 
     return backfilled
-

--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -14,7 +14,7 @@ from figures.models import SiteMonthlyMetrics
 from figures.sites import get_student_modules_for_site
 
 
-def backfill_monthly_metrics_for_site(site, overwrite):
+def backfill_monthly_metrics_for_site(site, overwrite=False):
     """Quick hack function to backfill all historical site metrics for the site
 
     We are a bit verbose with the output to help testing and validation since
@@ -38,7 +38,7 @@ def backfill_monthly_metrics_for_site(site, overwrite):
         mau = get_mau_from_student_modules(student_modules=site_sm,
                                            year=dt.year,
                                            month=dt.month)
-        month_sm = site_sm.filter(created__year=dt.year, created__month=dt.month)
+        month_sm = site_sm.filter(modified__year=dt.year, modified__month=dt.month)
         month_learners = month_sm.values_list('student__id', flat=True).distinct()
 
         obj, created = SiteMonthlyMetrics.add_month(
@@ -56,3 +56,4 @@ def backfill_monthly_metrics_for_site(site, overwrite):
         backfilled.append(backfill_rec)
 
     return backfilled
+

--- a/figures/management/commands/backfill_figures_metrics.py
+++ b/figures/management/commands/backfill_figures_metrics.py
@@ -11,6 +11,34 @@ from django.core.management.base import BaseCommand
 
 from figures.backfill import backfill_monthly_metrics_for_site
 
+def get_site(identifier):
+    """Quick-n-dirty function to let the caller choose the site id or domain
+    Let the 'get' fail if record can't be found from the identifier
+    """
+    try:
+        filter_arg = dict(pk=long(identifier))
+    except ValueError:
+        filter_arg = dict(domain=identifier)
+    return Site.objects.get(**filter_arg)
+
+
+def backfill_site(site, overwrite):
+
+    print('Backfilling monthly metrics for site id="{}" domain={}'.format(
+        site.id,
+        site.domain))
+    backfilled = backfill_monthly_metrics_for_site(site=site,
+                                                   overwrite=overwrite)
+    if backfilled:
+        for rec in backfilled:
+            obj = rec['obj']
+            print('Backfilled site "{}" for {} with active user count {}'.format(
+                obj.site.domain,
+                obj.month_for,
+                obj.active_user_count))
+    else:
+        print('No student modules for site "{}"'.format(site.domain))
+
 
 class Command(BaseCommand):
     """Populate Figures metrics models
@@ -24,28 +52,22 @@ class Command(BaseCommand):
                             action='store_true',
                             default=False,
                             help='overwrite existing data in SiteMonthlyMetrics')
+        parser.add_argument('--site',
+                            help='backfill a specific site. provide id or domain name')
 
     def handle(self, *args, **options):
         print('BEGIN: Backfill Figures Metrics')
 
-        # Would be great to be able to filter out dead sites
-        # Would be really great to be able to filter out dead sites
-        # Would be really Really great to be able to filter out dead sites
-        # Would be really Really REALLY great to be able to filter out dead sites
-        overwrite = options['overwrite']
-        for site in Site.objects.all():
-            print('Backfilling monthly metrics for site id="{}" domain={}'.format(
-                site.id,
-                site.domain))
-            backfilled = backfill_monthly_metrics_for_site(site=site,
-                                                           overwrite=overwrite)
-            if backfilled:
-                for rec in backfilled:
-                    obj = rec['obj']
-                    print('Backfilled site "{}" for {} with active user count {}'.format(
-                        obj.site.domain,
-                        obj.month_for,
-                        obj.active_user_count))
-            else:
-                print('No student modules for site "{}"'.format(site.domain))
+        if options['site']:
+            sites = [get_site(options['site'])]
+        else:
+            # Would be great to be able to filter out dead sites
+            # Would be really great to be able to filter out dead sites
+            # Would be really Really great to be able to filter out dead sites
+            # Would be really Really REALLY great to be able to filter out dead sites
+
+            sites = Site.objects.all()
+        for site in sites:
+            backfill_site(site, overwrite=options['overwrite'])
+
         print('DONE: Backfill Figures Metrics')

--- a/figures/management/commands/backfill_figures_metrics.py
+++ b/figures/management/commands/backfill_figures_metrics.py
@@ -11,6 +11,7 @@ from django.core.management.base import BaseCommand
 
 from figures.backfill import backfill_monthly_metrics_for_site
 
+
 def get_site(identifier):
     """Quick-n-dirty function to let the caller choose the site id or domain
     Let the 'get' fail if record can't be found from the identifier

--- a/figures/management/commands/run_figures_monthly_metrics.py
+++ b/figures/management/commands/run_figures_monthly_metrics.py
@@ -1,0 +1,36 @@
+"""Figures management command to manually start Celery tasks from the shell
+
+We're starting with the monthly metrics
+"""
+
+from __future__ import print_function
+
+from textwrap import dedent
+
+from django.core.management.base import BaseCommand
+
+from figures.tasks import (
+    run_figures_monthly_metrics
+)
+
+
+class Command(BaseCommand):
+    """Task runner to kick off Figures celery tasks
+    """
+    help = dedent(__doc__).strip()
+
+    def add_arguments(self, parser):
+        parser.add_argument('--no-delay',
+                            action='store_true',
+                            default=False,
+                            help='Disable the celery "delay" directive')
+
+    def handle(self, *args, **options):
+        print('Starting Figures monthly metrics...')
+
+        if options['no_delay']:
+            run_figures_monthly_metrics()
+        else:
+            run_figures_monthly_metrics.delay()
+
+        print('Done.')

--- a/figures/pipeline/site_monthly_metrics.py
+++ b/figures/pipeline/site_monthly_metrics.py
@@ -1,0 +1,40 @@
+"""Populate Figures site monthly metrics data
+
+"""
+
+from datetime import datetime
+from django.utils.timezone import utc
+from dateutil.relativedelta import relativedelta
+
+from figures.models import SiteMonthlyMetrics
+from figures.sites import get_student_modules_for_site
+
+
+def fill_month(site, month_for, student_modules=None, overwrite=False):
+    """Fill a month's site monthly metrics for the specified site
+    """
+    if not student_modules:
+        student_modules = get_student_modules_for_site(site)
+
+    if student_modules:
+        month_sm = student_modules.filter(modified__year=month_for.year,
+                                          modified__month=month_for.month)
+        mau_count = month_sm.values_list('student_id',
+                                         flat=True).distinct().count()
+    else:
+        mau_count = 0
+
+    obj, created = SiteMonthlyMetrics.add_month(site=site,
+                                                year=month_for.year,
+                                                month=month_for.month,
+                                                active_user_count=mau_count,
+                                                overwrite=overwrite)
+    return obj, created
+
+
+def fill_last_month(site, overwrite=False):
+    """Convenience function to fill previous month's site monthly metrics
+    """
+    # Maybe we want to make 'last_month' a 'figures.helpers' method
+    last_month = datetime.utcnow().replace(tzinfo=utc) - relativedelta(months=1)
+    return fill_month(site=site, month_for=last_month, overwrite=overwrite)

--- a/figures/settings/lms_production.py
+++ b/figures/settings/lms_production.py
@@ -49,6 +49,12 @@ def update_celerybeat_schedule(celerybeat_schedule_settings, figures_env_tokens)
                 ),
             }
 
+    if figures_env_tokens.get('ENABLE_FIGURES_MONTHLY_METRICS', False):
+        celerybeat_schedule_settings['figures-monthly-metrics'] = {
+            'task': 'figures.tasks.run_figures_monthly_metrics',
+            'schedule': crontab(0, 0, day_of_month=1),
+            }
+
 
 def plugin_settings(settings):
     """

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -21,6 +21,7 @@ from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader
 from figures.pipeline.site_daily_metrics import SiteDailyMetricsLoader
 import figures.sites
 from figures.pipeline.mau_pipeline import collect_course_mau
+from figures.pipeline.site_monthly_metrics import fill_last_month as fill_last_smm_month
 from figures.pipeline.logger import log_error_to_db
 
 
@@ -191,7 +192,7 @@ def experimental_populate_daily_metrics(date_for=None, force_update=False):
 
 
 #
-# MAU Metrics
+# Monthly Metrics
 #
 
 
@@ -245,3 +246,19 @@ def populate_all_mau():
     """
     for site in Site.objects.all():
         populate_mau_metrics_for_site(site_id=site.id, force_update=False)
+
+
+@shared_task
+def populate_monthly_metrics_for_site(site_id):
+    site = Site.objects.get(id=site_id)
+    fill_last_smm_month(site=site)
+
+
+@shared_task
+def run_figures_monthly_metrics():
+    """
+    TODO: only run for active sites. Requires knowing which sites we can skip
+    """
+    logger.info('Starting figures.tasks.run_figures_monthly_metrics...')
+    for site in Site.objects.all():
+        populate_monthly_metrics_for_site.delay(site_id=site.id)

--- a/tests/pipeline/test_site_monthly_metrics.py
+++ b/tests/pipeline/test_site_monthly_metrics.py
@@ -1,0 +1,96 @@
+"""Test figures.pipeline.site_monthly_metrics module
+
+This is initial test coverage
+
+"""
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+from django.utils.timezone import utc
+from freezegun import freeze_time
+import pytest
+
+from courseware.models import StudentModule
+
+from figures.models import SiteMonthlyMetrics
+from figures.pipeline.site_monthly_metrics import fill_month, fill_last_month
+
+from tests.factories import (
+    SiteFactory,
+    StudentModuleFactory,
+)
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def smm_test_data(db):
+    """
+    Minimal test data for very simple test case
+    """
+    site = SiteFactory()
+    mock_today = datetime(year=2020, month=2, day=1, tzinfo=utc)
+    last_month = mock_today - relativedelta(months=1)
+    month_before = last_month - relativedelta(months=1)
+    month_before_sm = [StudentModuleFactory(created=month_before,
+                                            modified=month_before)]
+    last_month_sm = [StudentModuleFactory(created=last_month,
+                                          modified=last_month) for i in range(2)]
+    return dict(site=site,
+                mock_today=mock_today,
+                last_month=last_month,
+                month_before=month_before,
+                last_month_sm=last_month_sm,
+                month_before_sm=month_before_sm)
+
+
+def test_fill_month_with_sm_wo_overwrite(monkeypatch, smm_test_data):
+    """
+    """
+    assert SiteMonthlyMetrics.objects.count() == 0
+    mock_today = smm_test_data['mock_today']
+    freezer = freeze_time(mock_today)
+    freezer.start()
+
+    site = smm_test_data['site']
+
+    def mock_get_student_modules_for_site(site):
+        assert site == site
+        return StudentModule.objects.all()
+
+    monkeypatch.setattr('figures.pipeline.site_monthly_metrics.get_student_modules_for_site',
+                        mock_get_student_modules_for_site)
+
+    obj, created = fill_month(site=site,
+                              month_for=smm_test_data['month_before'],
+                              student_modules=StudentModule.objects.all())
+    freezer.stop()
+
+    assert obj and created
+    assert obj.active_user_count == len(smm_test_data['month_before_sm'])
+    assert obj.site == site
+    assert obj.month_for == smm_test_data['month_before'].date()
+
+
+def test_fill_last_month_wo_overwrite(monkeypatch, smm_test_data):
+    """
+    """
+    assert SiteMonthlyMetrics.objects.count() == 0
+    mock_today = smm_test_data['mock_today']
+    freezer = freeze_time(mock_today)
+    freezer.start()
+
+    site = smm_test_data['site']
+
+    def mock_get_student_modules_for_site(site):
+        assert site == site
+        return StudentModule.objects.all()
+
+    monkeypatch.setattr('figures.pipeline.site_monthly_metrics.get_student_modules_for_site',
+                        mock_get_student_modules_for_site)
+
+    obj, created = fill_last_month(site=site)
+    freezer.stop()
+
+    assert obj and created
+    assert obj.active_user_count == len(smm_test_data['last_month_sm'])
+    assert obj.site == site
+    assert obj.month_for == smm_test_data['last_month'].date()

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -89,6 +89,10 @@ def test_backfill_monthly_metrics_for_site(backfill_test_data):
           True),
          (<SiteMonthlyMetrics: id:8, month_for:2020-04-01, site:site-0.example.com>,
           True)]
+
+    TODO: Update test data and test to have the created and modified dates different
+    and make sure that `modified` dates are used in the production code and not
+    `created` dates
     """
     site = backfill_test_data['site']
     count_check = backfill_test_data['count_check']


### PR DESCRIPTION

# Figures Pipeline core for monthly metrics

* Added figures.pipeline.site_monthly_metrics to provide functions to
fill site monthly MAU values
* Added tests for pipeline site monthly metrics
* Updated figures.backfill to use the new site monthly metrics pipeline
functions

# Figures monthly metrics Celery tasks

* Added tasks to run Figures monthly metrics to figures.tasks
  * Added tests, one is broken and needs to be fixed
* Added management command to manually start monthly metrics celery task
* Updated settins to start celery task on first day of month
 john/site-mau-fix