### PR TITLE
Initial implementation of Celery support for Figures devsite

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,4 @@ omit =
     setup.py
     tests/*
     mocks/*
+    devsite/devsite/celery.py

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,21 @@ ginkgo.pytest:  ## Run Pytest for the Ginkgo environment
 ginkgo.tox:  ## Run tox just for the Ginkgo environment
 	tox -e py27-ginkgo
 
+### Devsite Docker targets
+
+devsite.docker.prep: ## state needed to run devsite docker
+	pip install -e .
+
+devsite.docker.up: devsite.docker.prep  ## Start devsite docker
+	cd devsite; docker-compose up
+
+devsite.docker.rabbitmq.config:  ## configure RabbitMQ container
+	cd devsite; docker cp rabbitmq-init.sh devsite_rabbitmq_figures_1:/rabbitmq-init.sh ; \
+		docker exec devsite_rabbitmq_figures_1 /rabbitmq-init.sh
+
+devsite.docker.celery.start:  ## Start the celery server
+	cd devsite; celery -A devsite worker --logleve=info
+
 ### Automatically constructed Virtualenv based targets
 
 ve/bin/figures-ws: devsite/requirements/${EDX_PLATFORM_RELEASE}_appsembler.txt

--- a/devsite/README.md
+++ b/devsite/README.md
@@ -1,0 +1,103 @@
+# Figures Devsite
+
+
+## Overview
+
+This doc is a work in progress. Key details should exist, but needs fleshing out
+for readability and completeness
+
+
+## Status
+
+Figures devsite Celery support is in its initial phase. Devsite can now run
+Figures tasks asynchronously
+
+## Pipeline Sandbox
+
+Figures devsite has an option to run Celery tasks in devsite.
+
+
+### Requirements / Prerequisites
+
+Docker needs to be installed in your development environment
+
+### Setup and Configuration
+
+Note: This is a WIP
+
+We run the celery worker from the `figures/devsite` directory. It needs to discover Figures.
+
+Install Figures in the devsite venv:
+
+From the Figures project root directory, run:
+
+```
+pip install -e figures
+```
+
+
+* Start Docker on your development machine
+
+Go to the `figures/devsite` directory and from the shell, run `docker-compose up`
+
+This will launch the docker container and show console output
+
+In another shell, go to the `figures/devsite` directory and run
+
+```
+docker cp rabbitmq-init.sh devsite_rabbitmq_figures_1:/rabbitmq-init.sh
+```
+
+See the [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) CLI documentation.
+
+
+Run the following script to configure the Figures environment in RabbitMQ
+
+```
+docker exec devsite_rabbitmq_figures_1 /rabbitmq-init.sh
+```
+
+See the [docker exec](https://docs.docker.com/engine/reference/commandline/exec/) CLI documentation.
+
+Note: you can shell into the docker container with the following:
+
+```
+docker exec -ti devsite_rabbitmq_figures_1 /bin/bash
+```
+
+Update Figures devsite:
+
+
+```
+./manage.py createcachetable
+./manage.py migrate django_celery_results
+Operations to perform:
+  Apply all migrations: django_celery_results
+Running migrations:
+  Applying django_celery_results.0001_initial... OK
+  Applying django_celery_results.0002_add_task_name_args_kwargs... OK
+  Applying django_celery_results.0003_auto_20181106_1101... OK
+  Applying django_celery_results.0004_auto_20190516_0412... OK
+  Applying django_celery_results.0005_taskresult_worker... OK
+  Applying django_celery_results.0006_taskresult_date_created... OK
+  Applying django_celery_results.0007_remove_taskresult_hidden... OK
+```
+
+
+From the `figures/devsite` directory:
+
+```
+celery -A devsite worker --logleve=info
+```
+
+# Testing and Exploring
+
+In `figures/devsite`, run `./manage.py devsite_check`
+
+
+# References
+
+## Celery Results
+
+* https://github.com/celery/django-celery-results
+* https://stackoverflow.com/questions/26934522/celery-result-get-not-working

--- a/devsite/README.md
+++ b/devsite/README.md
@@ -23,79 +23,123 @@ Docker needs to be installed in your development environment
 
 ### Setup and Configuration
 
-Note: This is a WIP
+Note: This is an initial implementation. Steps may break.
 
-We run the celery worker from the `figures/devsite` directory. It needs to discover Figures.
+The setup and configuration instructions can be mostly run with makefile targets
+in `<figures-project-root>/Makefile`. The steps run from the makefile are also
+described following the makefile target steps
 
-Install Figures in the devsite venv:
+#### Background information
 
-From the Figures project root directory, run:
+* We run the celery worker from the `figures/devsite` directory.
+* The celery worker needs to discover Figures. In order to do so, we install Figures in the virtualenv we use for our project work. Because we are using Celery for Figures development, we install with the pip editable `-e` option. 
+* In addition to any terminals you currently open for your Figure development, we need two additional terminals
+  * RabbitMQ container
+  * Celery worker
 
-```
-pip install -e figures
-```
 
+#### Steps with Make
 
-* Start Docker on your development machine
+1. Go to your Figures project root,  For example `~/projects/figures`. Each time you need to open a new terminal window, you should activate your project's [Python virtual environment](https://www.pythonforbeginners.com/basics/how-to-use-python-virtualenv/). Ther term "Python virtual environment" is typically abbreviated to "venv", which we will use in the following instructions
 
-Go to the `figures/devsite` directory and from the shell, run `docker-compose up`
+2. Start your local [Docker](https://www.docker.com) server. Follow instructions specific to your development system's operating system
 
-This will launch the docker container and show console output
+3. Prepare your development docker environment. Open a terminal, activate your venv and run the following
 
-In another shell, go to the `figures/devsite` directory and run
+`make devsite.docker.prep`
+
+This step runs `pip install -e .` to install Figures in the virtualenv, which is needed by the Celery worker
+
+4. Start up Figures Docker containers. Open a terminal, activate your venv and run the following
+
+`make devsite.docker.up`
+
+This step changes directorey to `<figures-project-root>devsite` and runs `docker-compose up`
+
+5. Configure the RabbitMQ container. Open a terminal, activate your venv and run the following
+
+`make devsite.docker.rabbitmq.config`  
+
+This step changes directory to `<figures-project-root>devsite` and updates the RabbitMQ container, creates the figures user, adds a vhost for Figures, sets tags and permissions with the following calls
 
 ```
 docker cp rabbitmq-init.sh devsite_rabbitmq_figures_1:/rabbitmq-init.sh
-```
-
-See the [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) CLI documentation.
-
-
-Run the following script to configure the Figures environment in RabbitMQ
-
-```
 docker exec devsite_rabbitmq_figures_1 /rabbitmq-init.sh
 ```
 
-See the [docker exec](https://docs.docker.com/engine/reference/commandline/exec/) CLI documentation.
+Docker command reference
 
-Note: you can shell into the docker container with the following:
+* [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) CLI documentation.
+* [docker exec](https://docs.docker.com/engine/reference/commandline/exec/) CLI documentation.
+
+
+6. Run migration in Figures Django environment
+```
+./manage.py migrate djcelery
+Operations to perform:
+  Apply all migrations: djcelery
+Running migrations:
+  Applying djcelery.0001_initial... OK
+```
+
+
+7. Start your Celery worker. You can reuse the terminal from step 5 to start your celery worker. From an open terminal with the Figures venv activated, run the following
+
+`make devsite.docker.celery.start`
+
+8. Now you can test your Figures development environment Celery setup by running a diagnostic [Django management command](https://docs.djangoproject.com/en/3.0/howto/custom-management-commands/) in devsite. Open a terminal, activate your venv and run the following
+
+```
+cd <figures-project-root>/devsite
+./manage.py check_devsite
+```
+
+If all goes well, then you should see the following:
+
+
+from the terminal which you ran `check_devsite`
+
+
+```
+./manage.py check_devsite
+Figures devsite system check.
+Checking Celery...
+Task called. task_id=f9d3a72c-2a06-4ed4-9203-ada9df2be649
+result=figures-devsite-celery-check:run_devsite_check management command
+Done checking Celery
+Done.
+```
+
+And from the open Celery worker terminal window
+
+```
+[2020-06-26 21:30:48,777: INFO/MainProcess] Received task: devsite.celery.celery_check[f9d3a72c-2a06-4ed4-9203-ada9df2be649]
+[2020-06-26 21:30:48,789: WARNING/Worker-1] Called devsite.celery.celery.check with message "run_devsite_check management command"
+[2020-06-26 21:30:48,807: INFO/MainProcess] Task devsite.celery.celery_check[f9d3a72c-2a06-4ed4-9203-ada9df2be649] succeeded in 0.0195774619933s: u'figures-devsite-celery-check:run_devsite_check management command'
+```
+
+### Working with Figures Docker devsite
+
+_This section is a starting point to work with the Docker containers in the Figures development environment_
+
+You can shell into the RabbitMQ Docker container with the following:
 
 ```
 docker exec -ti devsite_rabbitmq_figures_1 /bin/bash
 ```
 
-Update Figures devsite:
-
-
-```
-./manage.py createcachetable
-./manage.py migrate django_celery_results
-Operations to perform:
-  Apply all migrations: django_celery_results
-Running migrations:
-  Applying django_celery_results.0001_initial... OK
-  Applying django_celery_results.0002_add_task_name_args_kwargs... OK
-  Applying django_celery_results.0003_auto_20181106_1101... OK
-  Applying django_celery_results.0004_auto_20190516_0412... OK
-  Applying django_celery_results.0005_taskresult_worker... OK
-  Applying django_celery_results.0006_taskresult_date_created... OK
-  Applying django_celery_results.0007_remove_taskresult_hidden... OK
-```
-
-
-From the `figures/devsite` directory:
-
-```
-celery -A devsite worker --logleve=info
-```
-
 # Testing and Exploring
 
-In `figures/devsite`, run `./manage.py devsite_check`
+In `figures/devsite`, run `./manage.py check_devsite`
 
 
 # References
+
+## Django Celery
+
+We need to use `django-celery` for Figures running and mocking Open edX Hawthorn. This is because Hawthorn runs Celery 3.1.x. With Celery 4.4.x, we won't need `django-celery` anymore
+
+* https://github.com/celery/django-celery
 
 ## Celery Results
 

--- a/devsite/devsite/__init__.py
+++ b/devsite/devsite/__init__.py
@@ -1,0 +1,10 @@
+"""Site init file
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/devsite/devsite/celery.py
+++ b/devsite/devsite/celery.py
@@ -1,0 +1,39 @@
+"""Site Celery setup
+"""
+
+from __future__ import absolute_import, unicode_literals
+import os
+from celery import Celery
+
+
+CELERY_CHECK_MSG_PREFIX = 'figures-devsite-celery-check'
+
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'devsite.settings')
+
+app = Celery('devsite')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))
+
+
+@app.task(bind=True)
+def celery_check(self, msg):
+    """Basic system check to check Celery results in devsite
+
+    Returns a value so that we can test Celery results backend configuration
+    """
+    print('Called devsite.celery.celery.check with message "{}"'.format(msg))
+    return '{prefix}:{msg}'.format(prefix=CELERY_CHECK_MSG_PREFIX, msg=msg)

--- a/devsite/devsite/management/commands/check_devsite.py
+++ b/devsite/devsite/management/commands/check_devsite.py
@@ -9,7 +9,7 @@ It calls the task `devsite.celery.run_celery_check`
 
 from django.core.management.base import BaseCommand
 
-from devsite.celery import run_celery_check
+from devsite.celery import celery_check
 
 
 class Command(BaseCommand):
@@ -25,7 +25,7 @@ class Command(BaseCommand):
         """
         print('Checking Celery...')
         msg = 'run_devsite_check management command'
-        result = run_celery_check.delay(msg)
+        result = celery_check.delay(msg)
         print('Task called. task_id={}'.format(result.task_id))
 
         try:

--- a/devsite/devsite/management/commands/check_devsite.py
+++ b/devsite/devsite/management/commands/check_devsite.py
@@ -1,0 +1,45 @@
+"""This command serves to run system checks for Figures devsite
+
+Initially, this is a convenience command to check that Celery on devsite works
+properly
+
+It calls the task `devsite.celery.run_celery_check`
+
+"""
+
+from django.core.management.base import BaseCommand
+
+from devsite.celery import run_celery_check
+
+
+class Command(BaseCommand):
+
+    def run_devsite_celery_task(self):
+        """Perform basic Celery checking
+
+        In production, we typically don't want to call `.get()`, but trying it
+        here just to see if the results backend is configured and working
+
+        See the `get` method here:
+            https://docs.celeryproject.org/en/stable/reference/celery.result.html
+        """
+        print('Checking Celery...')
+        msg = 'run_devsite_check management command'
+        result = run_celery_check.delay(msg)
+        print('Task called. task_id={}'.format(result.task_id))
+
+        try:
+            print('result={}'.format(result.get()))
+        except NotImplementedError as e:
+            print('Error: {}'.format(e))
+
+        print('Done checking Celery')
+
+    def add_arguments(self, parser):
+        """Stub"""
+        pass
+
+    def handle(self, *args, **options):
+        print('Figures devsite system check.')
+        self.run_devsite_celery_task()
+        print('Done.')

--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -171,17 +171,17 @@ REST_FRAMEWORK = {
 if ENABLE_DEVSITE_CELERY:
     # TODO: update to allow environemnt variable overrides
     # the password seting is only for local development environments
-    FIGURES_CELERY_USER='figures_user'
-    FIGURES_CELERY_PASSWORD='figures_pwd'
-    FIGURES_CELERY_VHOST='figures_vhost'
+    FIGURES_CELERY_USER = 'figures_user'
+    FIGURES_CELERY_PASSWORD = 'figures_pwd'
+    FIGURES_CELERY_VHOST = 'figures_vhost'
 
-    BROKER_URL='amqp://{user}:{password}@localhost:5672/{vhost}'.format(
+    BROKER_URL = 'amqp://{user}:{password}@localhost:5672/{vhost}'.format(
         user=FIGURES_CELERY_USER,
         password=FIGURES_CELERY_PASSWORD,
         vhost=FIGURES_CELERY_VHOST,
     )
 
-    CELERY_RESULT_BACKEND='djcelery.backends.cache:CacheBackend'
+    CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 
     import djcelery
     djcelery.setup_loader()

--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -36,7 +36,8 @@ ALLOWED_HOSTS = []
 # Set the default Site (django.contrib.sites.models.Site)
 SITE_ID = 1
 
-USE_CELERY_RESULTS = True
+# TODO: Update this to allow environment variable override
+ENABLE_DEVSITE_CELERY = True
 
 # Adds the mock edx-platform modules to the Python module search path
 sys.path.append(os.path.normpath(os.path.join(PROJECT_ROOT_DIR, MOCKS_DIR)))
@@ -70,8 +71,8 @@ INSTALLED_APPS = [
     'student',
 ]
 
-if USE_CELERY_RESULTS:
-    INSTALLED_APPS.append('django_celery_results')
+if ENABLE_DEVSITE_CELERY:
+    INSTALLED_APPS.append('djcelery')
 
 # certificates app
 
@@ -167,30 +168,23 @@ REST_FRAMEWORK = {
 }
 
 
-# Temporary and only for dev env, we want to get the secrets fro ENV
-# CELERY_BROKER_URL='amqp://celery_user:celery_pwd@localhost:5672/myvhost'
+if ENABLE_DEVSITE_CELERY:
+    # TODO: update to allow environemnt variable overrides
+    # the password seting is only for local development environments
+    FIGURES_CELERY_USER='figures_user'
+    FIGURES_CELERY_PASSWORD='figures_pwd'
+    FIGURES_CELERY_VHOST='figures_vhost'
 
-FIGURES_CELERY_USER='figures_user'
-FIGURES_CELERY_PASSWORD='figures_pwd'
-FIGURES_CELERY_VHOST='figures_vhost'
+    BROKER_URL='amqp://{user}:{password}@localhost:5672/{vhost}'.format(
+        user=FIGURES_CELERY_USER,
+        password=FIGURES_CELERY_PASSWORD,
+        vhost=FIGURES_CELERY_VHOST,
+    )
 
-CELERY_BROKER_URL='amqp://{user}:{password}@localhost:5672/{vhost}'.format(
-    user=FIGURES_CELERY_USER,
-    password=FIGURES_CELERY_PASSWORD,
-    vhost=FIGURES_CELERY_VHOST,
-)
+    CELERY_RESULT_BACKEND='djcelery.backends.cache:CacheBackend'
 
-if USE_CELERY_RESULTS:
-    CELERY_CACHE_BACKEND = 'default'
-
-    CELERY_CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
-            'LOCATION': 'devsite_cache'
-
-        }
-    }
-
+    import djcelery
+    djcelery.setup_loader()
 
 #
 # Declare empty dicts for settings required by Figures

--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -36,6 +36,8 @@ ALLOWED_HOSTS = []
 # Set the default Site (django.contrib.sites.models.Site)
 SITE_ID = 1
 
+USE_CELERY_RESULTS = True
+
 # Adds the mock edx-platform modules to the Python module search path
 sys.path.append(os.path.normpath(os.path.join(PROJECT_ROOT_DIR, MOCKS_DIR)))
 
@@ -67,6 +69,9 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.course_groups',
     'student',
 ]
+
+if USE_CELERY_RESULTS:
+    INSTALLED_APPS.append('django_celery_results')
 
 # certificates app
 
@@ -160,6 +165,31 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
     )
 }
+
+
+# Temporary and only for dev env, we want to get the secrets fro ENV
+# CELERY_BROKER_URL='amqp://celery_user:celery_pwd@localhost:5672/myvhost'
+
+FIGURES_CELERY_USER='figures_user'
+FIGURES_CELERY_PASSWORD='figures_pwd'
+FIGURES_CELERY_VHOST='figures_vhost'
+
+CELERY_BROKER_URL='amqp://{user}:{password}@localhost:5672/{vhost}'.format(
+    user=FIGURES_CELERY_USER,
+    password=FIGURES_CELERY_PASSWORD,
+    vhost=FIGURES_CELERY_VHOST,
+)
+
+if USE_CELERY_RESULTS:
+    CELERY_CACHE_BACKEND = 'default'
+
+    CELERY_CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+            'LOCATION': 'devsite_cache'
+
+        }
+    }
 
 
 #

--- a/devsite/docker-compose.yml
+++ b/devsite/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.5'
+services:
+
+  rabbitmq_figures:
+    # build: ./rabbitmq
+    image: rabbitmq:3
+    env_file: rabbitmq.env
+    ports:
+      - 5672:5672
+      - 15672:15672

--- a/devsite/rabbitmq-init.sh
+++ b/devsite/rabbitmq-init.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Run this script from within the RabbitMQ docker container
+
+rabbitmqctl add_user figures_user figures_pwd
+rabbitmqctl add_vhost figures_vhost
+rabbitmqctl set_user_tags figures_user figures_tag
+rabbitmqctl set_permissions -p figures_vhost figures_user ".*" ".*" ".*"

--- a/devsite/rabbitmq.env
+++ b/devsite/rabbitmq.env
@@ -1,0 +1,4 @@
+# RabbitMQ environment settings for Figures devsite
+
+RABBITMQ_DEFAULT_USER=rabbitadmin
+RABBITMQ_DEFAULT_PASS=gr0kBand

--- a/devsite/requirements/hawthorn_multisite.txt
+++ b/devsite/requirements/hawthorn_multisite.txt
@@ -10,6 +10,7 @@
 ###
 
 celery==3.1.25
+django-celery-results==1.2.1
 
 # Faker is used to seed mock data in devsite
 Faker==2.0.3

--- a/devsite/requirements/hawthorn_multisite.txt
+++ b/devsite/requirements/hawthorn_multisite.txt
@@ -10,7 +10,7 @@
 ###
 
 celery==3.1.25
-django-celery-results==1.2.1
+django-celery==3.3.1
 
 # Faker is used to seed mock data in devsite
 Faker==2.0.3


### PR DESCRIPTION
Please refer to the README.md file in the devsite directory for
instructions

* This commit adds a docker compose file with support files to start a
RabbitMQ docker container.
* Devsite is updaed to support Celery tasks running in this docker
container
* Conditional support for results backend is implemented, but not
working. Currently troubleshooting this
* Succesfully tested with running Figures `populate_figures_metrics` Django
management command. Figures daily metrics models get created with data
* Added a new Django management command in Devsite to do a system check.
This runs a "system check" task in `devsite/celery.py`


# NOTE

Although Figures devsite can now run Figures pipeline tasks asynchronously, there's still some debugging work to do to get the results backend working. So created as a draft PR because