### PR TITLE
Fixes incorrect site monthly metrics course completion data

### DIFF
--- a/figures/metrics.py
+++ b/figures/metrics.py
@@ -346,6 +346,7 @@ def get_total_site_users_joined_for_time_period(site, start_date, end_date,
     """returns the number of new enrollments for the time period
 
     NOTE: Untested and not yet used in the general site metrics, but we'll want to add it
+    TODO: Rename this function to be "new_users" for consistency with the API endpoint
     """
     def calc_from_user_model():
         filter_args = dict(

--- a/figures/views.py
+++ b/figures/views.py
@@ -565,6 +565,9 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
 
     @list_route()
     def new_users(self, request):
+        """
+        TODO: Rename the metrics module function to "new_users" to match this
+        """
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
         date_for = datetime.utcnow().date()
         months_back = 6
@@ -585,7 +588,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
         months_back = 6
 
         course_completions = metrics.get_monthly_history_metric(
-            func=metrics.get_total_site_users_for_time_period,
+            func=metrics.get_total_course_completions_for_time_period,
             site=site,
             date_for=date_for,
             months_back=months_back,


### PR DESCRIPTION
Site monthly metrics course completions API endpoint was retrieving
total site users erroneously. This was caused by 'copy/paste of the
viewset method and the mismatch never got caught. This is a good reason
why testing data quality on top of basic code coverage is important for
the API views

* https://appsembler.atlassian.net/browse/RED-1061