### PR TITLE
progress indicator for populate_daily_metrics

### DIFF
--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -101,7 +101,8 @@ def populate_daily_metrics(date_for=None, force_update=False):
     logger.info('Starting task "figures.populate_daily_metrics" for date "{}"'.format(
         date_for))
 
-    for site in Site.objects.all():
+    sites_count = Site.objects.count()
+    for i, site in enumerate(Site.objects.all()):
         for course in figures.sites.get_courses_for_site(site):
             try:
                 populate_single_cdm(
@@ -131,6 +132,8 @@ def populate_daily_metrics(date_for=None, force_update=False):
             site_id=site.id,
             date_for=date_for,
             force_update=force_update)
+        logger.info("figures.populate_daily_metrics: finished Site {:04d} of {:04d}".format(
+            i, sites_count))
 
     logger.info('Finished task "figures.populate_daily_metrics" for date "{}"'.format(
         date_for))


### PR DESCRIPTION
This is a simple quality of life improvement.

The daily pipeline takes a long time to run, and currently gives no indication of how far along in the process it is.

Adding a log message like this means that I can quickly tail the logs and form a ballpark estimate of how much longer it will be running. Eg, if we want to deploy (which we need to stop the pipeline for currently), seeing that it's at 1995 of 2000, I'd be inclined to just wait a few minutes for it to finish rather than stop the pipeline, deploy, and restart it.

Similarly, if it's been running for 12 hours and we see that it's only made it 10% of the way through, that would indicate that there's a bug or some issue slowing it down and we need to stop the pipeline and investigate before the next day's pipeline starts running and things get even worse.