### PR TITLE
Implement a new view: Learners Progress Overview

### DIFF
--- a/figures/filters.py
+++ b/figures/filters.py
@@ -144,10 +144,15 @@ class UserFilterSet(django_filters.FilterSet):
         replaced with spaces, so we need to put the '+' back in for CourseKey
         to be able to create a course key object from the string
         '''
-        course_key = CourseKey.from_string(value.replace(' ', '+'))
-        enrollments = get_enrolled_in_exclude_admins(course_id=course_key)
-        user_ids = enrollments.values_list('user__id', flat=True)
-        return queryset.filter(id__in=user_ids)
+        total_user_ids = []
+        if value is not None:
+            courseIds = value.split('|')
+            for courseId in courseIds:
+                course_key = CourseKey.from_string(courseId.replace(' ', '+'))
+                enrollments = get_enrolled_in_exclude_admins(course_id=course_key)
+                user_ids = enrollments.values_list('user__id', flat=True)
+                total_user_ids = total_user_ids + list(set(user_ids) - set(total_user_ids))
+        return queryset.filter(id__in=total_user_ids)
 
 
 class CourseDailyMetricsFilter(django_filters.FilterSet):

--- a/figures/views.py
+++ b/figures/views.py
@@ -380,8 +380,10 @@ class LearnerDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     model = get_user_model()
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = LearnerDetailsSerializer
-    filter_backends = (DjangoFilterBackend, )
+    filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
     filter_class = UserFilterSet
+    search_fields = ['username', 'email', 'profile__name']
+    ordering_fields = ['username', 'email', 'profile__name', 'is_active', 'date_joined']
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "7.4.0",
+    "export-to-csv": "^0.2.1",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "1.1.5",
     "fs-extra": "3.0.1",
@@ -37,6 +38,7 @@
     "iso-639-1": "^2.0.3",
     "jest": "^24.8.0",
     "moment": "^2.22.1",
+    "multiselect-react-dropdown": "^1.5.0",
     "node-sass": "^4.12.0",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",
@@ -71,6 +73,7 @@
     "webpack": "3.8.1",
     "webpack-bundle-tracker": "^0.4.2-beta",
     "webpack-manifest-plugin": "1.3.2",
+    "websocket-extensions": "0.1.4",
     "whatwg-fetch": "2.0.3"
   },
   "scripts": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import CsvReports from 'base/views/CsvReports';
 import SingleReportContent from 'base/views/SingleReportContent';
 import UsersList from 'base/views/UsersList';
 import CoursesList from 'base/views/CoursesList';
+import ProgressOverview from 'base/views/ProgressOverview';
 import 'base/sass/base/_base-overrides.scss';
 import styles from 'base/sass/base/_grid.scss';
 
@@ -47,6 +48,7 @@ class App extends Component {
                   <Route exact path="/figures/reports" component={ReportsList} />
                   <Route exact path="/figures/users" component={UsersList} />
                   <Route exact path="/figures/courses" component={CoursesList} />
+                  <Route exact path="/figures/progress-overview" component={ProgressOverview} />
                   {(process.env.ENABLE_CSV_REPORTS === "enabled") && <Route exact path="/figures/csv-reports" component={CsvReports} />}
                   <Route path="/figures/course/:courseId" render={({ match }) => <SingleCourseContent courseId={match.params.courseId} />}/>
                   <Route path="/figures/user/:userId" render={({ match }) => <SingleUserContent userId={match.params.userId} />}/>

--- a/frontend/src/apiConfig.js
+++ b/frontend/src/apiConfig.js
@@ -9,6 +9,7 @@ const apiConfig = {
   learnersGeneral: '/figures/api/users/general/',
   learnersDetailed: '/figures/api/users/detail/',
   reportingCsvReportsApi: '/reporting/api/csv-reports/',
+  coursesIndex: '/figures/api/courses-index/',
 }
 
 export default apiConfig;

--- a/frontend/src/components/layout/HeaderNav.js
+++ b/frontend/src/components/layout/HeaderNav.js
@@ -33,6 +33,12 @@ class HeaderNav extends Component {
         >
           Courses
         </NavLink>
+        <NavLink
+          to="/figures/progress-overview"
+          className={styles['header-nav__link']}
+        >
+          Progress Overview
+        </NavLink>
         {(process.env.ENABLE_CSV_REPORTS === "enabled") && (
           <NavLink
             to="/figures/csv-reports"

--- a/frontend/src/views/ProgressOverview.js
+++ b/frontend/src/views/ProgressOverview.js
@@ -1,0 +1,276 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import apiConfig from 'base/apiConfig';
+import { trackPromise } from 'react-promise-tracker';
+import styles from './_users-list-content.scss';
+import HeaderAreaLayout from 'base/components/layout/HeaderAreaLayout';
+import HeaderContentStatic from 'base/components/header-views/header-content-static/HeaderContentStatic';
+import Paginator from 'base/components/layout/Paginator';
+import ListSearch from 'base/components/inputs/ListSearch';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCheck, faAngleDoubleUp, faAngleDoubleDown } from '@fortawesome/free-solid-svg-icons';
+
+import classNames from 'classnames/bind';
+let cx = classNames.bind(styles);
+
+
+class ProgressOverview extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      ProgressOverview: [],
+      perPage: 20,
+      count: 0,
+      pages: 0,
+      currentPage: 1,
+      searchQuery: '',
+      ordering: 'profile__name',
+    };
+
+    this.getUsers = this.getUsers.bind(this);
+    this.setPerPage = this.setPerPage.bind(this);
+    this.setSearchQuery = this.setSearchQuery.bind(this);
+    this.setOrdering = this.setOrdering.bind(this);
+    this.constructApiUrl = this.constructApiUrl.bind(this);
+  }
+
+  constructApiUrl(rootUrl, searchQuery, orderingType, perPageLimit, resultsOffset) {
+    let requestUrl = rootUrl;
+    // add search term
+    requestUrl += '?search=' + searchQuery;
+    // add ordering
+    requestUrl += '&ordering=' + orderingType;
+    // add results per page limit
+    requestUrl += '&limit=' + perPageLimit;
+    // add results offset
+    requestUrl += '&offset=' + resultsOffset;
+    // return
+    return requestUrl;
+  }
+
+  getUsers(page = 1) {
+    const offset = (page-1) * this.state.perPage;
+    const requestUrl = this.constructApiUrl(apiConfig.learnersGeneral, this.state.searchQuery, this.state.ordering, this.state.perPage, offset);
+    trackPromise(
+      fetch((requestUrl), { credentials: "same-origin" })
+        .then(response => response.json())
+        .then(json => this.setState({
+          ProgressOverview: json['results'],
+          count: json['count'],
+          pages: Math.ceil(json['count'] / this.state.perPage),
+          currentPage: page,
+        })
+      )
+    )
+  }
+
+  setPerPage(newValue) {
+    this.setState({
+      perPage: newValue,
+    }, () => {
+      this.getUsers();
+    })
+  }
+
+  setSearchQuery(newValue) {
+    this.setState({
+      searchQuery: newValue
+    }, () => {
+      this.getUsers();
+    })
+  }
+
+  setOrdering(newValue) {
+    this.setState({
+      ordering: newValue
+    }, () => {
+      this.getUsers();
+    })
+  }
+
+  componentDidMount() {
+    this.getUsers();
+  }
+
+  render() {
+
+    const listItems = this.state.ProgressOverview.map((user, index) => {
+      return (
+        <li key={user['id']} className={styles['user-list-item']}>
+          <div className={styles['user-fullname']}>
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Full name:
+              </div>
+              <div className={styles['mobile-value']}>
+                <Link
+                  className={styles['user-fullname-link']}
+                  to={'/figures/user/' + user['id']}
+                >
+                  {user['fullname']}
+                </Link>
+              </div>
+            </div>
+          </div>
+          <div className={styles['username']}>
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Username:
+              </div>
+              <div className={styles['mobile-value']}>
+                {user['username']}
+              </div>
+            </div>
+          </div>
+          <div className={styles['is-active']}>
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Is activated:
+              </div>
+              <div className={styles['mobile-value']}>
+                {user['is_active'] ? <FontAwesomeIcon icon={faCheck} className={styles['checkmark-icon']} /> : '-'}
+              </div>
+            </div>
+          </div>
+          <div className={styles['date-joined']}>
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                Date joined:
+              </div>
+              <div className={styles['mobile-value']}>
+                {user['date_joined']}
+              </div>
+            </div>
+          </div>
+          <div className={styles['number-of-courses']}>
+            <div className={styles['in-cell-label-value']}>
+              <div className={styles['mobile-label']}>
+                No. of courses:
+              </div>
+              <div className={styles['mobile-value']}>
+                {user['courses'].length}
+              </div>
+            </div>
+          </div>
+          <div className={styles['action-container']}>
+            <Link
+              className={styles['user-action']}
+              to={'/figures/user/' + user['id']}
+            >
+              User details
+            </Link>
+          </div>
+        </li>
+      )
+    })
+
+    return (
+      <div className="ef--layout-root">
+        <HeaderAreaLayout>
+          <HeaderContentStatic
+            title='Users list'
+            subtitle={'This view allows you to browse your sites users. Total number of results: ' + this.state.count + '.'}
+          />
+        </HeaderAreaLayout>
+        <div className={cx({ 'container': true, 'users-content': true})}>
+          <ListSearch
+            valueChangeFunction={this.setSearchQuery}
+            inputPlaceholder='Search by users name, username or email...'
+          />
+          {this.state.pages ? (
+            <Paginator
+              pageSwitchFunction={this.getUsers}
+              currentPage={this.state.currentPage}
+              perPage={this.state.perPage}
+              pages={this.state.pages}
+              changePerPageFunction={this.setPerPage}
+            />
+          ) : ''}
+          <ul className={styles['users-list']}>
+            <li key='list-header' className={cx(styles['user-list-item'], styles['list-header'])}>
+              <div className={styles['user-fullname']}>
+                <button
+                  className={styles['sorting-header-button']}
+                  onClick={() => (this.state.ordering !== 'profile__name') ? this.setOrdering('profile__name') : this.setOrdering('-profile__name')}
+                >
+                  <span>
+                    User full name
+                  </span>
+                  {(this.state.ordering === 'profile__name') ? (
+                    <FontAwesomeIcon icon={faAngleDoubleUp} />
+                  ) : (this.state.ordering === '-profile__name') ? (
+                    <FontAwesomeIcon icon={faAngleDoubleDown} />
+                  ) : ''}
+                </button>
+              </div>
+              <div className={styles['username']}>
+                <button
+                  className={styles['sorting-header-button']}
+                  onClick={() => (this.state.ordering !== 'username') ? this.setOrdering('username') : this.setOrdering('-username')}
+                >
+                  <span>
+                    Username
+                  </span>
+                  {(this.state.ordering === 'username') ? (
+                    <FontAwesomeIcon icon={faAngleDoubleUp} />
+                  ) : (this.state.ordering === '-username') ? (
+                    <FontAwesomeIcon icon={faAngleDoubleDown} />
+                  ) : ''}
+                </button>
+              </div>
+              <div className={styles['is-active']}>
+                <button
+                  className={styles['sorting-header-button']}
+                  onClick={() => (this.state.ordering !== 'is_active') ? this.setOrdering('is_active') : this.setOrdering('-is_active')}
+                >
+                  <span>
+                    Is activated
+                  </span>
+                  {(this.state.ordering === 'is_active') ? (
+                    <FontAwesomeIcon icon={faAngleDoubleUp} />
+                  ) : (this.state.ordering === '-is_active') ? (
+                    <FontAwesomeIcon icon={faAngleDoubleDown} />
+                  ) : ''}
+                </button>
+              </div>
+              <div className={styles['date-joined']}>
+                <button
+                  className={styles['sorting-header-button']}
+                  onClick={() => (this.state.ordering !== 'date_joined') ? this.setOrdering('date_joined') : this.setOrdering('-date_joined')}
+                >
+                  <span>
+                    Date joined
+                  </span>
+                  {(this.state.ordering === 'date_joined') ? (
+                    <FontAwesomeIcon icon={faAngleDoubleUp} />
+                  ) : (this.state.ordering === '-date_joined') ? (
+                    <FontAwesomeIcon icon={faAngleDoubleDown} />
+                  ) : ''}
+                </button>
+              </div>
+              <div className={styles['number-of-courses']}>
+                Courses enroled in:
+              </div>
+              <div className={styles['action-container']}>
+
+              </div>
+            </li>
+            {listItems}
+          </ul>
+          {this.state.pages ? (
+            <Paginator
+              pageSwitchFunction={this.getUsers}
+              currentPage={this.state.currentPage}
+              perPage={this.state.perPage}
+              pages={this.state.pages}
+              changePerPageFunction={this.setPerPage}
+            />
+          ) : ''}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ProgressOverview

--- a/frontend/src/views/ProgressOverview.js
+++ b/frontend/src/views/ProgressOverview.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
+import Immutable from 'immutable';
 import { Link } from 'react-router-dom';
 import apiConfig from 'base/apiConfig';
 import { trackPromise } from 'react-promise-tracker';
-import styles from './_users-list-content.scss';
+import styles from './_progress-overview-content.scss';
 import HeaderAreaLayout from 'base/components/layout/HeaderAreaLayout';
 import HeaderContentStatic from 'base/components/header-views/header-content-static/HeaderContentStatic';
 import Paginator from 'base/components/layout/Paginator';
@@ -19,7 +20,10 @@ class ProgressOverview extends Component {
     super(props);
 
     this.state = {
-      ProgressOverview: [],
+      coursesIndex: [],
+      coursesList: [],
+      learnersList: [],
+      selectedCourses: [],
       perPage: 20,
       count: 0,
       pages: 0,
@@ -29,6 +33,8 @@ class ProgressOverview extends Component {
     };
 
     this.getUsers = this.getUsers.bind(this);
+    this.getCourses = this.getCourses.bind(this);
+    this.setCoursesIndex = this.setCoursesIndex.bind(this);
     this.setPerPage = this.setPerPage.bind(this);
     this.setSearchQuery = this.setSearchQuery.bind(this);
     this.setOrdering = this.setOrdering.bind(this);
@@ -49,14 +55,37 @@ class ProgressOverview extends Component {
     return requestUrl;
   }
 
+  getCourses() {
+    const requestUrl = apiConfig.coursesIndex + '?limit=1000';
+    trackPromise(
+      fetch((requestUrl), { credentials: "same-origin" })
+        .then(response => response.json())
+        .then(json => this.setCoursesIndex(json['results']))
+    )
+  }
+
+  setCoursesIndex(courses) {
+    let coursesIndex = {};
+    const coursesList = courses.map((course, index) => {
+      coursesIndex[course['id']] = course;
+      return course['id'];
+    })
+    this.setState({
+      coursesIndex: coursesIndex,
+      coursesList: coursesList,
+    }, () => {
+      console.log("done", this.state.coursesIndex, this.state.coursesList);
+    })
+  }
+
   getUsers(page = 1) {
     const offset = (page-1) * this.state.perPage;
-    const requestUrl = this.constructApiUrl(apiConfig.learnersGeneral, this.state.searchQuery, this.state.ordering, this.state.perPage, offset);
+    const requestUrl = this.constructApiUrl(apiConfig.learnersDetailed, this.state.searchQuery, this.state.ordering, this.state.perPage, offset);
     trackPromise(
       fetch((requestUrl), { credentials: "same-origin" })
         .then(response => response.json())
         .then(json => this.setState({
-          ProgressOverview: json['results'],
+          learnersList: json['results'],
           count: json['count'],
           pages: Math.ceil(json['count'] / this.state.perPage),
           currentPage: page,
@@ -90,77 +119,74 @@ class ProgressOverview extends Component {
   }
 
   componentDidMount() {
+    this.getCourses();
     this.getUsers();
   }
 
   render() {
 
-    const listItems = this.state.ProgressOverview.map((user, index) => {
+    const coursesFilter = this.state.selectedCourses.length ? this.state.selectedCourses : this.state.coursesList;
+
+    const headerCourseColumns = coursesFilter.map((course, index) => {
+      return(
+        <div className={styles['course-info-column']}>
+          {this.state.coursesIndex[course]['name']}
+        </div>
+      )
+    })
+
+    const floatingListItems = this.state.learnersList.map((user, index) => {
       return (
-        <li key={user['id']} className={styles['user-list-item']}>
+        <li key={`floating+${user['id']}`} className={styles['user-list-item']}>
           <div className={styles['user-fullname']}>
-            <div className={styles['in-cell-label-value']}>
-              <div className={styles['mobile-label']}>
-                Full name:
-              </div>
-              <div className={styles['mobile-value']}>
-                <Link
-                  className={styles['user-fullname-link']}
-                  to={'/figures/user/' + user['id']}
-                >
-                  {user['fullname']}
-                </Link>
-              </div>
-            </div>
-          </div>
-          <div className={styles['username']}>
-            <div className={styles['in-cell-label-value']}>
-              <div className={styles['mobile-label']}>
-                Username:
-              </div>
-              <div className={styles['mobile-value']}>
-                {user['username']}
-              </div>
-            </div>
-          </div>
-          <div className={styles['is-active']}>
-            <div className={styles['in-cell-label-value']}>
-              <div className={styles['mobile-label']}>
-                Is activated:
-              </div>
-              <div className={styles['mobile-value']}>
-                {user['is_active'] ? <FontAwesomeIcon icon={faCheck} className={styles['checkmark-icon']} /> : '-'}
-              </div>
-            </div>
-          </div>
-          <div className={styles['date-joined']}>
-            <div className={styles['in-cell-label-value']}>
-              <div className={styles['mobile-label']}>
-                Date joined:
-              </div>
-              <div className={styles['mobile-value']}>
-                {user['date_joined']}
-              </div>
-            </div>
-          </div>
-          <div className={styles['number-of-courses']}>
-            <div className={styles['in-cell-label-value']}>
-              <div className={styles['mobile-label']}>
-                No. of courses:
-              </div>
-              <div className={styles['mobile-value']}>
-                {user['courses'].length}
-              </div>
-            </div>
-          </div>
-          <div className={styles['action-container']}>
             <Link
-              className={styles['user-action']}
+              className={styles['user-fullname-link']}
               to={'/figures/user/' + user['id']}
             >
-              User details
+              {user['name']}
             </Link>
           </div>
+        </li>
+      )
+    });
+
+    const scrollingListItems = this.state.learnersList.map((user, index) => {
+
+      const userCoursesImmutable = Immutable.fromJS(user['courses']);
+      const userCoursesRender = coursesFilter.map((course, i) => {
+        console.log("course filter", course);
+        const userProgress = userCoursesImmutable.find(singleCourse => singleCourse.get('course_id') === course);
+        return (
+          <div className={styles['single-course-progress']}>
+            {userProgress ? [
+              <div className={styles['data-group']}>
+                <span className={styles['data-label']}>Sections</span>
+                <span className={styles['data']}>{userProgress.getIn(['progress_data', 'course_progress_details', 'sections_worked'])}/{userProgress.getIn(['progress_data', 'course_progress_details', 'sections_possible'])}</span>
+              </div>,
+              <div className={styles['data-group']}>
+                <span className={styles['data-label']}>Points</span>
+                <span className={styles['data']}>{userProgress.getIn(['progress_data', 'course_progress_details', 'points_earned'])}/{userProgress.getIn(['progress_data', 'course_progress_details', 'points_possible'])}</span>
+              </div>,
+              <div className={styles['data-group']}>
+                <span className={styles['data-label']}>Progress</span>
+                <span className={styles['data']}>{userProgress.getIn(['progress_data', 'course_progress'])*100}%</span>
+              </div>
+            ] : (
+              <span className={styles['no-data']}>-</span>
+            )}
+          </div>
+        )
+      })
+
+      return (
+        <li key={`scrolling+${user['id']}`} className={styles['user-list-item']}>
+          <div className={styles['username']}>
+            {user['username']}
+          </div>
+          <div className={styles['email']}>
+            {user['email']}
+          </div>
+          {userCoursesRender}
         </li>
       )
     })
@@ -169,11 +195,11 @@ class ProgressOverview extends Component {
       <div className="ef--layout-root">
         <HeaderAreaLayout>
           <HeaderContentStatic
-            title='Users list'
-            subtitle={'This view allows you to browse your sites users. Total number of results: ' + this.state.count + '.'}
+            title='Learners progress overview'
+            subtitle={'This view allows you to view a snapshot of your sites learners progress. Total number of results: ' + this.state.count + '.'}
           />
         </HeaderAreaLayout>
-        <div className={cx({ 'container': true, 'users-content': true})}>
+        <div className={cx({ 'container-max': true, 'users-content': true})}>
           <ListSearch
             valueChangeFunction={this.setSearchQuery}
             inputPlaceholder='Search by users name, username or email...'
@@ -187,77 +213,64 @@ class ProgressOverview extends Component {
               changePerPageFunction={this.setPerPage}
             />
           ) : ''}
-          <ul className={styles['users-list']}>
-            <li key='list-header' className={cx(styles['user-list-item'], styles['list-header'])}>
-              <div className={styles['user-fullname']}>
-                <button
-                  className={styles['sorting-header-button']}
-                  onClick={() => (this.state.ordering !== 'profile__name') ? this.setOrdering('profile__name') : this.setOrdering('-profile__name')}
-                >
-                  <span>
-                    User full name
-                  </span>
-                  {(this.state.ordering === 'profile__name') ? (
-                    <FontAwesomeIcon icon={faAngleDoubleUp} />
-                  ) : (this.state.ordering === '-profile__name') ? (
-                    <FontAwesomeIcon icon={faAngleDoubleDown} />
-                  ) : ''}
-                </button>
-              </div>
-              <div className={styles['username']}>
-                <button
-                  className={styles['sorting-header-button']}
-                  onClick={() => (this.state.ordering !== 'username') ? this.setOrdering('username') : this.setOrdering('-username')}
-                >
-                  <span>
-                    Username
-                  </span>
-                  {(this.state.ordering === 'username') ? (
-                    <FontAwesomeIcon icon={faAngleDoubleUp} />
-                  ) : (this.state.ordering === '-username') ? (
-                    <FontAwesomeIcon icon={faAngleDoubleDown} />
-                  ) : ''}
-                </button>
-              </div>
-              <div className={styles['is-active']}>
-                <button
-                  className={styles['sorting-header-button']}
-                  onClick={() => (this.state.ordering !== 'is_active') ? this.setOrdering('is_active') : this.setOrdering('-is_active')}
-                >
-                  <span>
-                    Is activated
-                  </span>
-                  {(this.state.ordering === 'is_active') ? (
-                    <FontAwesomeIcon icon={faAngleDoubleUp} />
-                  ) : (this.state.ordering === '-is_active') ? (
-                    <FontAwesomeIcon icon={faAngleDoubleDown} />
-                  ) : ''}
-                </button>
-              </div>
-              <div className={styles['date-joined']}>
-                <button
-                  className={styles['sorting-header-button']}
-                  onClick={() => (this.state.ordering !== 'date_joined') ? this.setOrdering('date_joined') : this.setOrdering('-date_joined')}
-                >
-                  <span>
-                    Date joined
-                  </span>
-                  {(this.state.ordering === 'date_joined') ? (
-                    <FontAwesomeIcon icon={faAngleDoubleUp} />
-                  ) : (this.state.ordering === '-date_joined') ? (
-                    <FontAwesomeIcon icon={faAngleDoubleDown} />
-                  ) : ''}
-                </button>
-              </div>
-              <div className={styles['number-of-courses']}>
-                Courses enroled in:
-              </div>
-              <div className={styles['action-container']}>
-
-              </div>
-            </li>
-            {listItems}
-          </ul>
+          <div className={styles['users-overview-list']}>
+            <ul className={styles['list-floating-columns']}>
+              <li key='list-header' className={cx(styles['user-list-item'], styles['list-header'])}>
+                <div className={styles['user-fullname']}>
+                  <button
+                    className={styles['sorting-header-button']}
+                    onClick={() => (this.state.ordering !== 'profile__name') ? this.setOrdering('profile__name') : this.setOrdering('-profile__name')}
+                  >
+                    <span>
+                      User full name
+                    </span>
+                    {(this.state.ordering === 'profile__name') ? (
+                      <FontAwesomeIcon icon={faAngleDoubleUp} />
+                    ) : (this.state.ordering === '-profile__name') ? (
+                      <FontAwesomeIcon icon={faAngleDoubleDown} />
+                    ) : ''}
+                  </button>
+                </div>
+              </li>
+              {floatingListItems}
+            </ul>
+            <ul className={styles['list-scrolling-columns']}>
+              <li key='list-header' className={cx(styles['user-list-item'], styles['list-header'])}>
+                <div className={styles['username']}>
+                  <button
+                    className={styles['sorting-header-button']}
+                    onClick={() => (this.state.ordering !== 'username') ? this.setOrdering('username') : this.setOrdering('-username')}
+                  >
+                    <span>
+                      Username
+                    </span>
+                    {(this.state.ordering === 'username') ? (
+                      <FontAwesomeIcon icon={faAngleDoubleUp} />
+                    ) : (this.state.ordering === '-username') ? (
+                      <FontAwesomeIcon icon={faAngleDoubleDown} />
+                    ) : ''}
+                  </button>
+                </div>
+                <div className={styles['email']}>
+                  <button
+                    className={styles['sorting-header-button']}
+                    onClick={() => (this.state.ordering !== 'email') ? this.setOrdering('email') : this.setOrdering('-email')}
+                  >
+                    <span>
+                      Email
+                    </span>
+                    {(this.state.ordering === 'username') ? (
+                      <FontAwesomeIcon icon={faAngleDoubleUp} />
+                    ) : (this.state.ordering === '-username') ? (
+                      <FontAwesomeIcon icon={faAngleDoubleDown} />
+                    ) : ''}
+                  </button>
+                </div>
+                {headerCourseColumns}
+              </li>
+              {scrollingListItems}
+            </ul>
+          </div>
           {this.state.pages ? (
             <Paginator
               pageSwitchFunction={this.getUsers}

--- a/frontend/src/views/_progress-overview-content.scss
+++ b/frontend/src/views/_progress-overview-content.scss
@@ -20,12 +20,12 @@
 
   .user-fullname {
     width: 100%;
+    padding-left: calcRem(15);
     padding-top: calcRem(20);
     padding-bottom: calcRem(20);
     padding-right: calcRem(15);
     display: flex;
     align-items: center;
-    border-bottom: 1px solid #ccc;
   }
 }
 
@@ -40,12 +40,10 @@
     flex-shrink: 0;
     padding-left: calcRem(15);
     padding-right: calcRem(15);
-    border-left: 1px solid #ccc;
     padding-top: calcRem(20);
     padding-bottom: calcRem(20);
     display: flex;
     align-items: center;
-    border-bottom: 1px solid #ccc;
   }
 
   .email {
@@ -55,12 +53,10 @@
     flex-shrink: 0;
     padding-right: calcRem(15);
     padding-left: calcRem(15);
-    border-left: 1px solid #ccc;
     padding-top: calcRem(20);
     padding-bottom: calcRem(20);
     display: flex;
     align-items: center;
-    border-bottom: 1px solid #ccc;
   }
 
   .course-info-column, .single-course-progress {
@@ -70,13 +66,11 @@
     flex-shrink: 0;
     padding-right: calcRem(15);
     padding-left: calcRem(15);
-    border-left: 1px solid #ccc;
     padding-top: calcRem(20);
     padding-bottom: calcRem(20);
     display: flex;
     align-items: center;
     justify-content: center;
-    border-bottom: 1px solid #ccc;
   }
 
   .single-course-progress {
@@ -113,13 +107,19 @@
 
 .users-list {
   padding: calcRem(25) 0;
-  border-top: 1px solid #ccc;
 }
 
 .user-list-item {
   font-size: calcRem(14);
   height: calcRem(80);
   display: flex;
+
+  &:nth-child(even) {
+
+    .user-fullname, .username, .email, .single-course-progress {
+      background-color: #eee;
+    }
+  }
 
   &.list-header {
     font-size: calcRem(12);
@@ -145,7 +145,93 @@
 
   .user-fullname-link {
     color: $primary-color;
-    font-weight: bold;
     text-decoration: none;
+  }
+}
+
+button.export-the-csv-button {
+  padding: calcRem(15) calcRem(30);
+  color: #fff;
+  display: inline-block;
+  background-color: $primary-color !important;
+  border: none;
+  outline: none;
+  border-radius: 50px;
+  margin-left: auto;
+  transition: all 0.3s ease-in-out;
+
+  &:hover {
+    cursor: pointer;
+    background-color: darken($primary-color, 15%) !important;
+  }
+}
+
+.refining-container {
+  display: flex;
+  align-items: center;
+
+  &__filters {
+    width: 50%;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+    grid-column-gap: calcRem(30);
+  }
+}
+
+.csv-export-content {
+  min-height: calcRem(500);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: calcRem(80) calcRem(30);
+
+  h2 {
+    font-size: calcRem(24);
+    text-align: center;
+    margin: 0 0 calcRem(20);
+  }
+
+  .progress-bar {
+    width: 100%;
+    max-width: calcRem(500);
+    height: calcRem(18);
+    border-radius: calcRem(30);
+    padding: 4px;
+    border: 1px solid #ddd;
+    margin: calcRem(40) 0 calcRem(20);
+    overflow: hidden;
+  }
+
+  .progress-bar-inner {
+    display: block;
+    height: 100%;
+    background-color: $primary-color;
+    border-radius: calcRem(30);
+  }
+
+  .percentage {
+    display: block;
+    text-align: center;
+    font-size: calcRem(14);
+    color: #aaa;
+  }
+}
+
+button.close-csv-button {
+  padding: calcRem(15) calcRem(30);
+  color: #fff;
+  display: inline-block;
+  background-color: $primary-color !important;
+  border: none;
+  outline: none;
+  border-radius: 50px;
+  transition: all 0.3s ease-in-out;
+
+  &:hover {
+    cursor: pointer;
+    background-color: darken($primary-color, 15%) !important;
   }
 }

--- a/frontend/src/views/_progress-overview-content.scss
+++ b/frontend/src/views/_progress-overview-content.scss
@@ -1,0 +1,151 @@
+@import '~base/sass/base/variables';
+@import '~base/sass/base/functions';
+@import '~base/sass/base/grid';
+@import '~base/sass/base/mixins';
+@import '~base/sass/base/stat-cards';
+
+.container-max {
+  padding-left: calcRem(50);
+  padding-right: calcRem(50);
+}
+
+.users-overview-list {
+  padding-top: calcRem(30);
+  display: grid;
+  grid-template-columns: calcRem(200) 1fr;
+}
+
+.list-floating-columns {
+  padding: 0;
+
+  .user-fullname {
+    width: 100%;
+    padding-top: calcRem(20);
+    padding-bottom: calcRem(20);
+    padding-right: calcRem(15);
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid #ccc;
+  }
+}
+
+.list-scrolling-columns {
+  overflow-x: auto;
+  padding: 0;
+
+  .username {
+    width: calcRem(140);
+    font-size: calcRem(13);
+    flex-grow: 0;
+    flex-shrink: 0;
+    padding-left: calcRem(15);
+    padding-right: calcRem(15);
+    border-left: 1px solid #ccc;
+    padding-top: calcRem(20);
+    padding-bottom: calcRem(20);
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid #ccc;
+  }
+
+  .email {
+    width: calcRem(210);
+    font-size: calcRem(13);
+    flex-grow: 0;
+    flex-shrink: 0;
+    padding-right: calcRem(15);
+    padding-left: calcRem(15);
+    border-left: 1px solid #ccc;
+    padding-top: calcRem(20);
+    padding-bottom: calcRem(20);
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid #ccc;
+  }
+
+  .course-info-column, .single-course-progress {
+    width: calcRem(200);
+    text-align: center;
+    flex-grow: 0;
+    flex-shrink: 0;
+    padding-right: calcRem(15);
+    padding-left: calcRem(15);
+    border-left: 1px solid #ccc;
+    padding-top: calcRem(20);
+    padding-bottom: calcRem(20);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-bottom: 1px solid #ccc;
+  }
+
+  .single-course-progress {
+
+    .data-group {
+      padding: 0 calcRem(7);
+      text-align: center;
+      width: 33%;
+
+      .data-label {
+        display: block;
+        font-size: calcRem(11);
+        color: #aaa;
+        margin: 0 0 calcRem(5) 0;
+      }
+
+      .data {
+        display: block;
+      }
+
+      .no-data {
+        color: #aaa;
+      }
+    }
+  }
+}
+
+
+
+
+.users-content {
+
+}
+
+.users-list {
+  padding: calcRem(25) 0;
+  border-top: 1px solid #ccc;
+}
+
+.user-list-item {
+  font-size: calcRem(14);
+  height: calcRem(80);
+  display: flex;
+
+  &.list-header {
+    font-size: calcRem(12);
+  }
+
+  .sorting-header-button {
+    padding: 0;
+    margin: 0;
+    background: none;
+    border: none;
+    outline: none;
+
+    span {
+      margin-right: calcRem(5);
+      text-decoration: underline;
+      font-size: calcRem(12);
+    }
+
+    &:hover, &:focus {
+      cursor: pointer;
+    }
+  }
+
+  .user-fullname-link {
+    color: $primary-color;
+    font-weight: bold;
+    text-decoration: none;
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3531,6 +3531,11 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
+export-to-csv@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/export-to-csv/-/export-to-csv-0.2.1.tgz#8f997156feebc1cf995096da16341aa0100cce4e"
+  integrity sha512-KTbrd3CAZ0cFceJEZr1e5uiMasabeCpXq1/5uvVxDl53o4jXJHnltasQoj2NkzrxD8hU9kdwjnMhoir/7nNx/A==
+
 express@^4.13.3:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -6144,6 +6149,14 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+multiselect-react-dropdown@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/multiselect-react-dropdown/-/multiselect-react-dropdown-1.5.0.tgz#c0eca3f4661dc19ce042d5c9c49caac86b8936ff"
+  integrity sha512-Ke1fbh75IoGSZCRFaILaVLx9VZvSf779GBGUWC3EwcPJn6mYjKuiQdUUu0pRukZQvfC3nCVTSaeswLPQaFHeww==
+  dependencies:
+    react "^16.7.0"
+    react-dom "^16.7.0"
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -7350,6 +7363,16 @@ react-dom@^16.5.2:
     prop-types "^15.6.2"
     scheduler "^0.16.2"
 
+react-dom@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
 react-draggable@3.x, react-draggable@^3.0.3:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-3.3.2.tgz#966ef1d90f2387af3c2d8bd3516f601ea42ca359"
@@ -7528,6 +7551,15 @@ react@^16.5.2:
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react/-/react-16.10.2.tgz#a5ede5cdd5c536f745173c8da47bda64797a4cf0"
   integrity sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -8084,6 +8116,14 @@ scheduler@^0.16.2:
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.16.2.tgz#f74cd9d33eff6fc554edfb79864868e4819132c1"
   integrity sha512-BqYVWqwz6s1wZMhjFvLfVR5WXP7ZY32M/wYPo04CcuPM7XZEbV2TBNW7Z0UkguPTl0dWMA59VbNXxK6q+pHItg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -9427,6 +9467,11 @@ websocket-driver@>=0.5.1:
     http-parser-js ">=0.4.0 <0.4.11"
     safe-buffer ">=5.1.0"
     websocket-extensions ">=0.1.1"
+
+websocket-extensions@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 websocket-extensions@>=0.1.1:
   version "0.1.3"


### PR DESCRIPTION
Per requests by our users, we found that we are missing a central point of overview for learner progress. That is why we are working on implementing this new view: Learners Progress Overview. It allows to view the progress of _all learners_ in _all courses_ at the _same time_. It also allows to filter out certain courses to only show the learners that have enrolled in them, as well as having a search enabled (by email, username or full name). After creating your filtered and sorted view, you can export the data from this view as a CSV on-the-fly from the frontend.

**Note: _while the view is ready for testing, we need to figure out how to test this out (especially CSV generation) in production against a serious amount of data. My recommendation is to temporarily remove the menu link for this new view and push it to production, then access it directly using the URL and test it out in real world. I'm also open for other suggestions._**

![Screenshot 2020-06-22 at 18 08 55](https://user-images.githubusercontent.com/10602234/85309920-9a5aa980-b4b3-11ea-9e84-47352c653014.jpg)
