### PR TITLE
Bump Figures to 0.3.12 + tweak to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
+/ve
 
 # Spyder project settings
 .spyderproject
@@ -118,7 +119,9 @@ devsite/*.sqlite3
 # Vi, Vim, swap
 *.swp
 
-# misc folders
+# misc folders and files used in the workspace
 scratch
 sandbox
-
+/scratch.py
+/scratch.txt
+/notes

--- a/README.rst
+++ b/README.rst
@@ -8,20 +8,47 @@ Reporting and data retrieval app for `Open edX <https://open.edx.org/>`__.
 
 .. _notice_section:
 
+15 Jul 2020 - Figures release 0.3.12
+====================================
+
+* Adds enrollment metrics API endpoint
+
+  * https://github.com/appsembler/figures/pull/233
+
+* Site monthly metrics API performance improvement
+
+  * https://github.com/appsembler/figures/pull/234
+
+* Initial implementation of Celery support for Figures devsite
+
+  * https://github.com/appsembler/figures/pull/215
+
+
 29 Jun 2020 - Figures release 0.3.11
 ====================================
 
 * Fixes incorrect site monthly metrics course completion data
+
   * https://github.com/appsembler/figures/pull/219
+
 * Fixes CourseDailyMetricsSerializer when average_progress is 1.00
+
   * https://github.com/appsembler/figures/pull/230
+
 * Updates pipeline enrollment metrics queries to improve performance
+
   * https://github.com/appsembler/figures/pull/226
+
 * Added site pipeline progress indicator to logging
+
   * https://github.com/appsembler/figures/pull/228
+
 * Bump devsite Django 1.11 to version 1.11.29
+
   * https://github.com/appsembler/figures/pull/227
+
 * Bump websocket-extensions from 0.1.3 to 0.1.4 in /frontend
+
   * https://github.com/appsembler/figures/pull/222
 
 
@@ -29,8 +56,11 @@ Reporting and data retrieval app for `Open edX <https://open.edx.org/>`__.
 ====================================
 
 * Improved daily metrics pipeline performance
+
   * https://github.com/appsembler/figures/pull/214
+
 * Bug fixes
+
   * https://github.com/appsembler/figures/pull/213
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='Figures',
-    version='0.3.11',
+    version='0.3.12',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',


### PR DESCRIPTION
The .gitignore update untracks the following
* The ./ve/ directory created with the Makefile. This is some experimental work to automatically manage the
virtualenv when working with Figures makefile targets
* ./notes,  ./scratch.py, and ./scratch.txt - working files and notes
folder not meant to be added to the repo