### PR TITLE
Learner metrics endpoint - Prerelease for evaluation

### DIFF
--- a/figures/urls.py
+++ b/figures/urls.py
@@ -100,12 +100,20 @@ router.register(
     views.UserIndexViewSet,
     base_name='user-index')
 
-# Experimental
+
+# New endpoints in development (unstable)
+# Unstable here means the code is subject to change without notice
 
 router.register(
     r'enrollment-metrics',
     views.EnrollmentMetricsViewSet,
     base_name='enrollment-metrics')
+
+router.register(
+    r'learner-metrics',
+    views.LearnerMetricsViewSet,
+    base_name='learner-metrics')
+
 
 urlpatterns = [
 

--- a/figures/views.py
+++ b/figures/views.py
@@ -64,6 +64,7 @@ from figures.serializers import (
     EnrollmentMetricsSerializer,
     GeneralCourseDataSerializer,
     LearnerDetailsSerializer,
+    LearnerMetricsSerializer,
     SiteDailyMetricsSerializer,
     SiteMauMetricsSerializer,
     SiteMauLiveMetricsSerializer,
@@ -394,6 +395,35 @@ class LearnerDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
 
     def get_serializer_context(self):
         context = super(LearnerDetailsViewSet, self).get_serializer_context()
+        context['site'] = django.contrib.sites.shortcuts.get_current_site(self.request)
+        return context
+
+
+class LearnerMetricsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
+    """Provides user identity and nested enrollment data
+
+    This view is unders active development and subject to change
+
+    TODO: After we get this class tests running, restructure this module:
+    * Group all user model based viewsets together
+    * Make a base user viewset with the `get_queryset` and `get_serializer_context`
+      methods
+    """
+    model = get_user_model()
+    pagination_class = FiguresLimitOffsetPagination
+    serializer_class = LearnerMetricsSerializer
+    filter_backends = (DjangoFilterBackend, )
+
+    # TODO: Improve this filter
+    filter_class = UserFilterSet
+
+    def get_queryset(self):
+        site = django.contrib.sites.shortcuts.get_current_site(self.request)
+        queryset = figures.sites.get_users_for_site(site)
+        return queryset
+
+    def get_serializer_context(self):
+        context = super(LearnerMetricsViewSet, self).get_serializer_context()
         context['site'] = django.contrib.sites.shortcuts.get_current_site(self.request)
         return context
 

--- a/tests/views/test_learner_metrics_viewset.py
+++ b/tests/views/test_learner_metrics_viewset.py
@@ -1,0 +1,165 @@
+"""Tests Figures learner-metrics viewset
+"""
+
+import pytest
+
+import django.contrib.sites.shortcuts
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from figures.sites import get_user_ids_for_site
+from figures.views import LearnerMetricsViewSet
+
+from tests.factories import (
+    CourseEnrollmentFactory,
+    CourseOverviewFactory,
+    # LearnerCourseGradeMetricsFactory,
+    OrganizationFactory,
+    SiteFactory,
+    UserFactory,
+)
+
+from tests.helpers import organizations_support_sites
+from tests.views.base import BaseViewTest
+from tests.views.helpers import is_response_paginated
+
+if organizations_support_sites():
+    from tests.factories import UserOrganizationMappingFactory
+
+    def map_users_to_org_site(caller, site, users):
+        org = OrganizationFactory(sites=[site])
+        UserOrganizationMappingFactory(user=caller,
+                                       organization=org,
+                                       is_amc_admin=True)
+        [UserOrganizationMappingFactory(user=user,
+                                        organization=org) for user in users]
+        # return created objects that the test will need
+        return caller
+
+
+@pytest.fixture
+def enrollment_test_data():
+    """Stands up shared test data. We need to revisit this
+    """
+    num_courses = 2
+    site = SiteFactory()
+    course_overviews = [CourseOverviewFactory() for i in range(num_courses)]
+    # Create a number of enrollments for each course
+    enrollments = []
+    for num_enroll, co in enumerate(course_overviews, 1):
+        enrollments += [CourseEnrollmentFactory(
+            course_id=co.id) for i in range(num_enroll)]
+
+    # This is a convenience for the test method
+    users = [enrollment.user for enrollment in enrollments]
+    return dict(
+        site=site,
+        course_overviews=course_overviews,
+        enrollments=enrollments,
+        users=users,
+    )
+
+
+@pytest.mark.django_db
+class TestLearnerMetricsViewSet(BaseViewTest):
+    """Tests the learner metrics viewset
+
+    The tests are incomplete
+
+    The list action will return a list of the following records:
+
+    ```
+        {
+            "id": 109,
+            "username": "chasecynthia",
+            "email": "msnyder@gmail.com",
+            "fullname": "Brandon Meyers",
+            "is_active": true,
+            "date_joined": "2020-06-03T00:00:00Z",
+            "enrollments": [
+                {
+                    "id": 9,
+                    "course_id": "course-v1:StarFleetAcademy+SFA01+2161",
+                    "date_enrolled": "2020-02-24",
+                    "is_enrolled": true,
+                    "progress_percent": 1.0,
+                    "progress_details": {
+                        "sections_worked": 20,
+                        "points_possible": 100.0,
+                        "sections_possible": 20,
+                        "points_earned": 50.0
+                    }
+                }
+            ]
+        }
+    ```
+    """
+    base_request_path = 'api/learner-metrics/'
+    view_class = LearnerMetricsViewSet
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db, settings):
+        if organizations_support_sites():
+            settings.FEATURES['FIGURES_IS_MULTISITE'] = True
+        super(TestLearnerMetricsViewSet, self).setup(db)
+
+    def make_caller(self, site, users):
+        """Convenience method to create the API caller user
+        """
+        if organizations_support_sites():
+            # TODO: set is_staff to False after we have test coverage
+            caller = UserFactory(is_staff=True)
+            map_users_to_org_site(caller=caller, site=site, users=users)
+        else:
+            caller = UserFactory(is_staff=True)
+        return caller
+
+    def make_request(self, monkeypatch, request_path, site, caller, action):
+        """Convenience method to make the API request
+
+        Returns the response object
+        """
+        request = APIRequestFactory().get(request_path)
+        request.META['HTTP_HOST'] = site.domain
+        monkeypatch.setattr(django.contrib.sites.shortcuts,
+                            'get_current_site',
+                            lambda req: site)
+        force_authenticate(request, user=caller)
+        view = self.view_class.as_view({'get': action})
+        return view(request)
+
+    def test_list_method_all(self, monkeypatch, enrollment_test_data):
+        """Partial test coverage to check we get all site users
+
+        Checks returned user ids against all user ids for the site
+        Checks top level keys
+
+        Does NOT check values in the `enrollments` key. This should be done as
+        follow up work
+        """
+        site = enrollment_test_data['site']
+        users = enrollment_test_data['users']
+        enrollments = enrollment_test_data['enrollments']
+
+        caller = self.make_caller(site, users)
+        other_site = SiteFactory()
+        assert site.domain != other_site.domain
+
+        response = self.make_request(request_path=self.base_request_path,
+                                     monkeypatch=monkeypatch,
+                                     site=site,
+                                     caller=caller,
+                                     action='list')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert is_response_paginated(response.data)
+        results = response.data['results']
+
+        # Check user ids
+        result_ids = [obj['id'] for obj in results]
+        user_ids = get_user_ids_for_site(site=site)
+        assert set(result_ids) == set(user_ids)
+        # Spot check the first record
+        top_keys = ['id', 'username', 'email', 'fullname', 'is_active',
+                    'date_joined', 'enrollments']
+        assert set(results[0].keys()) == set(top_keys)


### PR DESCRIPTION
This PR is for the initial evaluation version of the learner metrics endpoint for Matej's implementation on the front end and evaluation in production.

The endpoint is `/figures/api/learner-metrics/`

* There is a basic viewset just to exercise the code. The test requires test data to be filled out and tested in the response

* UserFilterSet needs to be updated or an alternate filter set needs to be used in order to provide more filtering, in particular
 * Show only users who have enrollments
 * Show only users who do not have enrollments
 * Show only users who have completed
 * Show only users who have not completed

* List serializers need to be added to prefetch data to improve API performance
* test_learner_metrics_viewset needs to be completed
* Updated the CourseEnrollment mock to provide the `is_enrolled` method