### PR TITLE
John/learner metrics multi course filtering

### DIFF
--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -888,4 +888,8 @@ class LearnerMetricsSerializer(serializers.ModelSerializer):
         site_enrollments = figures.sites.get_course_enrollments_for_site(
             self.context.get('site'))
         user_enrollments = site_enrollments.filter(user=user)
+        course_keys = self.context.get('course_keys')
+        if course_keys:
+            user_enrollments = user_enrollments.filter(course_id__in=course_keys)
+
         return EnrollmentMetricsSerializerV2(user_enrollments, many=True).data

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -210,6 +210,23 @@ def course_enrollments_for_course(course_id):
     return CourseEnrollment.objects.filter(course_id=as_course_key(course_id))
 
 
+def enrollments_for_course_ids(course_ids):
+    """
+    figures.sites is a temporary home for this function
+    """
+    ckeys = [as_course_key(cid) for cid in course_ids]
+    return CourseEnrollment.objects.filter(course_id__in=ckeys)
+
+
+def users_enrolled_in_courses(course_ids):
+    """
+    figures.sites is a temporary home for this function
+    """
+    enrollments = enrollments_for_course_ids(course_ids)
+    user_ids = enrollments.order_by('user_id').values('user_id').distinct()
+    return get_user_model().objects.filter(id__in=user_ids)
+
+
 def student_modules_for_course_enrollment(ce):
     """Return a queryset of all `StudentModule` records for a `CourseEnrollment`1
 

--- a/frontend/src/views/ProgressOverview.js
+++ b/frontend/src/views/ProgressOverview.js
@@ -41,8 +41,10 @@ class ProgressOverview extends Component {
     let requestUrl = rootUrl;
     // add search term
     requestUrl += '?search=' + searchQuery;
-    // add course filtering
-    requestUrl += '&enrolled_in_course_id=' + selectedCourseIds;
+    // optionally add course filtering
+    if (selectedCourseIds) {
+      requestUrl += '&course=' + selectedCourseIds;
+    }
     // add ordering
     requestUrl += '&ordering=' + orderingType;
     // add results per page limit
@@ -121,7 +123,7 @@ class ProgressOverview extends Component {
     const selectedIdsList = selectedList.map((course, index) => {
       return course.id;
     });
-    const selectedCourseIds = selectedIdsList.join(',');
+    const selectedCourseIds = selectedIdsList.join('&course=');
     this.setState({
       selectedCourses: selectedList,
       selectedCourseIds: selectedCourseIds,

--- a/frontend/src/views/ProgressOverview.js
+++ b/frontend/src/views/ProgressOverview.js
@@ -181,7 +181,6 @@ class ProgressOverview extends Component {
 
   convertJsonToCsvSchema = (jsonData) => {
     const csvTestVar = jsonData.map((user, index) => {
-      console.log("sve", user);
       const singleRecord = {};
       singleRecord['name'] = user['fullname'];
       singleRecord['email'] = user['email'];

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -331,3 +331,36 @@ def test_site_iterator():
         collected_ids.append(site_id)
 
     assert set(collected_ids) == set([site.id for site in sites])
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def enrollment_data(db):
+    """Test data for course id filtering
+    """
+    course_overviews = [CourseOverviewFactory() for i in range(2)]
+    expected_enrollments = []
+    for co in course_overviews:
+        expected_enrollments += [CourseEnrollmentFactory(course_id=co.id)
+                                 for i in range(2)]
+    # Create enrollment we don't want
+    other_enrollment = CourseEnrollmentFactory()
+    return dict(
+        course_overviews=course_overviews,
+        expected_enrollments=expected_enrollments,
+        other_enrollment=other_enrollment)
+
+
+def test_enrollments_for_course_ids(enrollment_data):
+    course_ids = [co.id for co in enrollment_data['course_overviews']]
+    expected_enrollments = enrollment_data['expected_enrollments']
+    enrollments = figures.sites.enrollments_for_course_ids(course_ids)
+    assert set(enrollments) == set(expected_enrollments)
+
+
+def test_users_enrolled_in_courses(enrollment_data):
+    course_ids = [co.id for co in enrollment_data['course_overviews']]
+    expected_enrollments = enrollment_data['expected_enrollments']
+    expected_users = [ce.user for ce in expected_enrollments]
+    users = figures.sites.users_enrolled_in_courses(course_ids)
+    assert set(users) == set(expected_users)


### PR DESCRIPTION
This PR adds multiple course filtering for the `learner-metrics` endpoint.


# New functions to support filtering 

Adds two functions to figures.sites. This is to support multi-course
filtering for the learner-metrics endpoint

1. enrollments_for_course_ids

This retrieves a CourseEnrollment queryset for enrollments that belong
to the list of course ids argument

2. users_enrolled_in_courses

This retrieves a User queryset for users that are enrolled in the
courses identified by the course ids argument

Added tests for the new functionality

# New learner-metrics query parameter, "course=<course-id>" 

The `learner-metrics` endpoint now filters on one or more courses using
'course=some-course-id` query parameters. To filter on multiple courses,
simply do multiple parameters of the same "course" key. Example

```
?course-my-first-course-id&course=my-second-course-id
```

* Added query param tests to the learner metrics viewset test class