### PR TITLE
Add Learners Progress Overview to main menu

### DIFF
--- a/frontend/src/components/layout/HeaderNav.js
+++ b/frontend/src/components/layout/HeaderNav.js
@@ -33,6 +33,12 @@ class HeaderNav extends Component {
         >
           Courses
         </NavLink>
+        <NavLink
+          to="/figures/learners-progress-overview"
+          className={styles['header-nav__link']}
+        >
+          Learners Progress Overview
+        </NavLink>
         {(process.env.ENABLE_CSV_REPORTS === "enabled") && (
           <NavLink
             to="/figures/csv-reports"


### PR DESCRIPTION
This is the final step for releasing the new feature. After all testing is done, when the feature is ready for release, this is to be merged to add the menu item.

<img width="1283" alt="Screenshot 2020-09-10 at 13 51 00" src="https://user-images.githubusercontent.com/10602234/92725744-dee83980-f36c-11ea-98bd-78f845442890.png">
