### PR TITLE
Ginkgo backward compatibility fix for Django Filters

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,6 +3,16 @@
 Currently uses Django TestCase style classes instead of pytest style classes
 so that we can use TestCase.assertQuerysetEqual
 
+
+Test Debt
+=========
+Field parameters 'lookup_type' and 'lookup_expr'
+
+We are not adequately testing 'lookup_exr', which is supported only in
+Django Filters 1.0.0 and greater. Prior to Django Filters 1.0.0, 'lookup_type'
+was used.
+
+Open edX Ginkgo uses Django Filteres 0.11.0.
 '''
 
 from dateutil.parser import parse as dateutil_parse


### PR DESCRIPTION
Django Filters < 1.0.0 requires 'lookup_type' instead of 'lookup_expr'
for CharField expression. This commit adds a `char_filter` method to
`figures.filters` to address this compatibility issue. The `char_filter`
function was copied and adapted from the `figures/filteres.py` update
from the JJuniper upgrade PR:

https://github.com/appsembler/figures/pull/264

IMPORTANT: We did not update `tests/test_filters.py` at this time in
order to save development time. We may revisit this decision

After this is merged to master, I will

1. Cherry pick and create a PR to Dicey-Tech/figures Juniper branch
2. Cut a 'build-ginkgo-testing' branch off of master to test this on our customer's Ginkgo staging server