### PR TITLE
Bump to version 0.3.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   - tox
 
 env:
+  - TOXENV=py27-ginkgo
   - TOXENV=py27-hawthorn_community
   - TOXENV=py27-hawthorn_multisite
   - TOXENV=lint

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,26 @@ Reporting and data retrieval app for `Open edX <https://open.edx.org/>`__.
 
 .. _notice_section:
 
+16 Oct 2020 - Figures release 0.3.17
+====================================
+
+* Reworked SiteMonthlyMetrics registered users metric. This was causing the `/figures/api/site-monthly-metrics/registered_users` endpoint to timeout with a 500 error
+
+  * https://github.com/appsembler/figures/pull/268
+
+* Fixed Ginkgo (Django Filter 0.11.0) Backward compatibility issues
+
+  * https://github.com/appsembler/figures/pull/266
+  * https://github.com/appsembler/figures/pull/269
+
+* UI Bug fix: Add success feedback to csv export dialog
+
+  * https://github.com/appsembler/figures/pull/265
+
+* Bump http-proxy from 1.18.0 to 1.18.1 in /frontend
+
+  * https://github.com/appsembler/figures/pull/254
+
 
 28 Sep 2020 - Figures release 0.3.16
 ====================================

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='Figures',
-    version='0.3.16',
+    version='0.3.17',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',


### PR DESCRIPTION
The usual version increment

* bump point version
* Update main readme w/ version release note

But, going to see if codecov still gets stuck and tweak the travisci file a bit if it still is to see if we can get it unstuck