### PR TITLE
Reverted Pylint from 1.9.5 to 1.9.4 because of PyPI error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ python.clean:  ## Removes generated Python bytecode files
 	find devsite -type f -name "*.pyc" -exec rm -f {} \;
 	find mocks -type f -name "*.pyc" -exec rm -f {} \;
 	find tests -type d -name __pycache__ -exec rm -r {} \+
+	find figures -type d -name __pycache__ -exec rm -r {} \+
 	find devsite -type d -name __pycache__ -exec rm -r {} \+
 	find mocks -type d -name __pycache__ -exec rm -r {} \+
 

--- a/devsite/requirements/hawthorn_multisite.txt
+++ b/devsite/requirements/hawthorn_multisite.txt
@@ -71,7 +71,7 @@ django-debug-toolbar==1.11
 coverage==4.5.4
 factory-boy==2.5.1
 flake8==3.7.9
-pylint==1.9.5
+pylint==1.9.4	# Because "No matching distribution found for pylint==1.9.5"
 pylint-django==0.11.1
 pytest==3.6.2
 pytest-django==3.1.2


### PR DESCRIPTION
Using Pip 20.2.3

```
pip install pylint==1.9.5ERROR: Could not find a version that satisfies the requirement pylint==1.9.5 (from versions: 0.15.2, 0.16.0, 0.18.0, 0.18.1, 0.19.0, 0.20.0, 0.21.0, 0.21.1, 0.21.2, 0.21.3, 0.22.0, 0.23.0, 0.24.0, 0.25.0, 0.25.1, 0.25.2, 0.26.0, 0.27.0, 0.28.0, 1.0.0, 1.1.0, 1.2.0, 1.2.1, 1.3.0, 1.3.1, 1.4.0, 1.4.1, 1.4.2, 1.4.3, 1.4.4, 1.4.5, 1.5.0, 1.5.1, 1.5.2, 1.5.3, 1.5.4, 1.5.5, 1.5.6, 1.6.0, 1.6.1, 1.6.2, 1.6.3, 1.6.4, 1.6.5, 1.7.0, 1.7.1, 1.7.2, 1.7.3, 1.7.4, 1.7.5, 1.7.6, 1.8.0, 1.8.1, 1.8.2, 1.8.3, 1.8.4, 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.9.4, 2.0.0.dev0, 2.0.0.dev1, 2.0.0.dev2, 2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.2.0, 2.2.1, 2.2.2, 2.2.3, 2.3.0.dev0, 2.3.0.dev1, 2.3.0.dev2, 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.6.0)ERROR: No matching distribution found for pylint==1.9.5
```

Even though Pylint 1.9.5 seems to exist in PyPI

This commit also updates the Makefile `python.clean` target to remove
`__pycache__` directories from the `figures` package source directory
hierarchy.