### PR TITLE
Use the Open edX named releases to conditionally import platform objects

### DIFF
--- a/figures/compat.py
+++ b/figures/compat.py
@@ -11,46 +11,45 @@ a lowercase string, such as 'ginkgo' or 'hawthorn'
 # pylint: disable=ungrouped-imports,useless-suppression
 
 from __future__ import absolute_import
+
+
+class UnsuportedOpenedXRelease(Exception):
+    pass
+
+
+# Pre-Ginkgo does not define `RELEASE_LINE`
 try:
     from openedx.core.release import RELEASE_LINE
 except ImportError:
-    # we are pre-ginkgo
-    RELEASE_LINE = None
-
-try:
-    # First try to import for the path as of hawthorn
-    from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
-except ImportError:
-    try:
-        # Next try to import for the path as of ginkgo
-        from lms.djangoapps.grades.new.course_grade_factory import CourseGradeFactory
-    except ImportError:
-        # try the pre-ginkgo path
-        from lms.djangoapps.grades.new.course_grade import CourseGradeFactory    # noqa: F401
+    raise UnsuportedOpenedXRelease(
+        'Unidentified Open edX release: '
+        'figures.compat could not import openedx.core.release.RELEASE_LINE')
 
 
 if RELEASE_LINE == 'ginkgo':
+    from lms.djangoapps.grades.new.course_grade_factory import CourseGradeFactory  # noqa pylint: disable=unused-import,import-error
+else:  # Assume Hawthorn or greater
+    from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory  # noqa pylint: disable=unused-import,import-error
+
+if RELEASE_LINE == 'ginkgo':
     from certificates.models import GeneratedCertificate  # noqa pylint: disable=unused-import,import-error
-else:
+else:  # Assume Hawthorn or greater
     from lms.djangoapps.certificates.models import GeneratedCertificate  # noqa pylint: disable=unused-import,import-error
 
-
-try:
-    from lms.djangoapps.courseware.models import StudentModule  # noqa pylint: disable=unused-import,import-error
-except ImportError:
-    # Backward compatibily for pre-Juniper releases
+if RELEASE_LINE in ['ginkgo', 'hawthorn']:
     from courseware.models import StudentModule  # noqa pylint: disable=unused-import,import-error
+else:  # Assume Juniper or greater
+    from lms.djangoapps.courseware.models import StudentModule  # noqa pylint: disable=unused-import,import-error
 
-try:
-    from lms.djangoapps.courseware.courses import get_course_by_id  # noqa pylint: disable=unused-import,import-error
-except ImportError:
-    # Backward compatibily for pre-Juniper releases
+if RELEASE_LINE in ['ginkgo', 'hawthorn']:
     from courseware.courses import get_course_by_id  # noqa pylint: disable=unused-import,import-error
+else:  # Assume Juniper or greater
+    from lms.djangoapps.courseware.courses import get_course_by_id  # noqa pylint: disable=unused-import,import-error
 
-try:
-    from opaque_keys.edx.django.models import CourseKeyField  # noqa pylint: disable=unused-import,import-error
-except ImportError:
+if RELEASE_LINE == 'ginkgo':
     from openedx.core.djangoapps.xmodule_django.models import CourseKeyField  # noqa pylint: disable=unused-import,import-error
+else:  # Assume Hawthorn or greater
+    from opaque_keys.edx.django.models import CourseKeyField  # noqa pylint: disable=unused-import,import-error
 
 
 def course_grade(learner, course):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     pass
 
-from mock import Mock, patch
+from mock import patch
 
 
 def patch_module(module_path, extra_properties=None):
@@ -60,55 +60,105 @@ def patch_module(module_path, extra_properties=None):
     return patch.dict('sys.modules', patch_specs)
 
 
-@patch('openedx.core.release.RELEASE_LINE', 'ginkgo')
-def test_release_line_with_ginkgo():
-    '''Make sure that ``figures.compat.RELEASE_LINE`` is 'ginkgo'
-    '''
-    with patch_module('certificates.models', {'GeneratedCertificate': Mock()}):  # Just to avoid an error
-        import figures.compat
-        reload(figures.compat)
-        assert figures.compat.RELEASE_LINE == 'ginkgo'
-
-
-# For the ginkgo tests, we need to first remove finding the hawthorn module
-
-def test_course_grade_factory_with_ginkgo():
-    hawthorn_key = 'lms.djangoapps.grades.course_grade_factory'
-    with patch.dict('sys.modules', {hawthorn_key: None}):
-        with patch_module('lms.djangoapps.grades.new.course_grade_factory', {'CourseGradeFactory': 'hi'}):
-            import figures.compat
-            reload(figures.compat)
-            assert figures.compat.CourseGradeFactory == 'hi'
-
-
-@patch('openedx.core.release.RELEASE_LINE', 'hawthorn')
-def test_course_grade_factory_with_hawthorn():
-    with patch_module('lms.djangoapps.certificates.models', {'GeneratedCertificate': Mock()}):  # Just to avoid an error
-        with patch_module('lms.djangoapps.grades.course_grade_factory', {'CourseGradeFactory': 'hi'}):
-            import figures.compat
-            reload(figures.compat)
-            assert hasattr(figures.compat, 'CourseGradeFactory')
-            assert figures.compat.CourseGradeFactory == 'hi'
+# TODO: Test with no release line
 
 
 @patch('openedx.core.release.RELEASE_LINE', 'ginkgo')
-def test_generated_certificate_pre_hawthorn():
-    mock =  Mock()
-    with patch_module('certificates.models', {'GeneratedCertificate': mock}):
-        import figures.compat
-        reload(figures.compat)
-        assert hasattr(figures.compat, 'GeneratedCertificate')
-        assert figures.compat.GeneratedCertificate is mock
+def test_compat_module_with_ginkgo():
+    """Test Ginkgo compat path works
+
+    Yes, we have a number of assertions here. We are testing the state of
+    `figures.compat` when we expect Figures to run in Ginkgo. Running in one
+    test also saves execution time as we need to ste up the whole module to
+    import as Ginkgo even if we are only testing one object in the module
+    """
+    with patch_module('lms.djangoapps.grades.new.course_grade_factory',
+                      {'CourseGradeFactory': 'cgf'}):
+        with patch_module('certificates.models', {'GeneratedCertificate': 'gc'}):
+            with patch_module('courseware.models', {'StudentModule': 'sm'}):
+                with patch_module('courseware.courses', {'get_course_by_id': 'gcbid'}):
+                    with patch_module('openedx.core.djangoapps.xmodule_django.models',
+                                      {'CourseKeyField': 'ckf'}):
+                        import figures.compat
+                        reload(figures.compat)
+                        assert figures.compat.RELEASE_LINE == 'ginkgo'
+                        assert hasattr(figures.compat, 'CourseGradeFactory')
+                        assert figures.compat.CourseGradeFactory == 'cgf'
+                        assert hasattr(figures.compat, 'GeneratedCertificate')
+                        assert figures.compat.GeneratedCertificate == 'gc'
+                        assert hasattr(figures.compat, 'StudentModule')
+                        assert figures.compat.StudentModule == 'sm'
+                        assert hasattr(figures.compat, 'get_course_by_id')
+                        assert figures.compat.get_course_by_id == 'gcbid'
+                        assert hasattr(figures.compat, 'CourseKeyField')
+                        assert figures.compat.CourseKeyField == 'ckf'
 
 
 @patch('openedx.core.release.RELEASE_LINE', 'hawthorn')
-def test_generated_certificate_hawthorn():
-    hawthorn_key = 'lms.djangoapps.certificates.models'
-    with patch_module(hawthorn_key, {'GeneratedCertificate': 'hi'}):
-        import figures.compat
-        reload(figures.compat)
-        assert hasattr(figures.compat, 'GeneratedCertificate')
-        assert figures.compat.GeneratedCertificate == 'hi'
+def test_release_line_with_hawthorn():
+    """Test Hawthorn compat path works
+
+    Yes, we have a number of assertions here. We are testing the state of
+    `figures.compat` when we expect Figures to run in Ginkgo. Running in one
+    test also saves execution time as we need to ste up the whole module to
+    import as Ginkgo even if we are only testing one object in the module
+    """
+    with patch_module('lms.djangoapps.grades.course_grade_factory',
+                      {'CourseGradeFactory': 'cgf'}):
+        with patch_module('lms.djangoapps.certificates.models',
+                          {'GeneratedCertificate': 'gc'}):
+            with patch_module('courseware.models', {'StudentModule': 'sm'}):
+                with patch_module('courseware.courses',
+                                  {'get_course_by_id': 'gcbid'}):
+                    with patch_module('opaque_keys.edx.django.models',
+                                      {'CourseKeyField': 'ckf'}):
+                        import figures.compat
+                        reload(figures.compat)
+                        assert figures.compat.RELEASE_LINE == 'hawthorn'
+                        assert hasattr(figures.compat, 'CourseGradeFactory')
+                        assert figures.compat.CourseGradeFactory == 'cgf'
+                        assert hasattr(figures.compat, 'GeneratedCertificate')
+                        assert figures.compat.GeneratedCertificate == 'gc'
+                        assert hasattr(figures.compat, 'StudentModule')
+                        assert figures.compat.StudentModule == 'sm'
+                        assert hasattr(figures.compat, 'get_course_by_id')
+                        assert figures.compat.get_course_by_id == 'gcbid'
+                        assert hasattr(figures.compat, 'CourseKeyField')
+                        assert figures.compat.CourseKeyField == 'ckf'
+
+
+@patch('openedx.core.release.RELEASE_LINE', 'juniper')
+def test_release_line_with_juniper():
+    """Test Hawthorn compat path works
+
+    Yes, we have a number of assertions here. We are testing the state of
+    `figures.compat` when we expect Figures to run in Ginkgo. Running in one
+    test also saves execution time as we need to ste up the whole module to
+    import as Ginkgo even if we are only testing one object in the module
+    """
+    with patch_module('lms.djangoapps.grades.course_grade_factory',
+                      {'CourseGradeFactory': 'cgf'}):
+        with patch_module('lms.djangoapps.certificates.models',
+                          {'GeneratedCertificate': 'gc'}):
+            with patch_module('lms.djangoapps.courseware.models',
+                              {'StudentModule': 'sm'}):
+                with patch_module('lms.djangoapps.courseware.courses',
+                                  {'get_course_by_id': 'gcbid'}):
+                    with patch_module('opaque_keys.edx.django.models',
+                                      {'CourseKeyField': 'ckf'}):
+                        import figures.compat
+                        reload(figures.compat)
+                        assert figures.compat.RELEASE_LINE == 'juniper'
+                        assert hasattr(figures.compat, 'CourseGradeFactory')
+                        assert figures.compat.CourseGradeFactory == 'cgf'
+                        assert hasattr(figures.compat, 'GeneratedCertificate')
+                        assert figures.compat.GeneratedCertificate == 'gc'
+                        assert hasattr(figures.compat, 'StudentModule')
+                        assert figures.compat.StudentModule == 'sm'
+                        assert hasattr(figures.compat, 'get_course_by_id')
+                        assert figures.compat.get_course_by_id == 'gcbid'
+                        assert hasattr(figures.compat, 'CourseKeyField')
+                        assert figures.compat.CourseKeyField == 'ckf'
 
 
 @pytest.mark.parametrize('chapter_grades, expected', [


### PR DESCRIPTION
This commit exists to address the problem that a RuntimeError can be
raised instead of an ImportError when importing objects from
ed-platform.

The options to fix are check for ImportError AND RuntimeError. However,
we opt (at least for now) to check the Open edX named release to
conditionally import objects when the namespace has changed between
named releases.

Here is an example of the error when only ImportError is handled:
```
RuntimeError: Conflicting 'studentmodule' models in application 'courseware': <class 'courseware.models.StudentModule'> and <class 'lms.djangoapps.courseware.models.StudentModule'>.
```

NOTE: This may break Juniper compat as it was not tested in a live
Juniper devstack

NOTE: See @OmarIthawi 's comments and this issue: https://github.com/appsembler/figures/issues/290