### PR TITLE
Added sqlparse dependency and bump figures versioun to 0.4.dev1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='Figures',
-    version='0.4.0',
+    version='0.4.dev1',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',
@@ -57,4 +57,7 @@ setup(
             'figures = figures.apps:FiguresConfig',
         ],
     },
+    install_requires=[
+        'sqlparse >= 0.2.2',  # This is the requirement specified by Django 2.2+
+    ],
 )


### PR DESCRIPTION
This PR addresses the issue that `sqlparse` is not installed on `edx-platform` Hawthorn. Also changing the Figures version number for 0.4.dev? releases, following https://www.python.org/dev/peps/pep-0440/

To note, Django 2.2.x has a dependency on sqlparse. See here: https://github.com/django/django/blob/stable/2.2.x/setup.py#L86
