### PR TITLE
Fixed ViewSets with course id detail views

### DIFF
--- a/devsite/devsite/test_settings.py
+++ b/devsite/devsite/test_settings.py
@@ -16,6 +16,9 @@ from figures.settings.lms_production import (
 )
 
 
+COURSE_ID_PATTERN = r'(?P<course_id>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
+
+
 def root(*args):
     """
     Get the absolute path of the given path relative to the project root.


### PR DESCRIPTION
The problem was that course ids with dots in the name would get part of
the url before the course id into the PK for the 'retrieve' call, which
provides a detail view of the single course based content.

The fix was adding `lookup_value_regex` to the Course based model
viewsets

As part of this:

* Refactored figures/views.py to DRY up code
* Added logging when an invalid course id is used as a primary key and
purposefully raising a `NotFound` exception instead of an
`InvalidKeyError`

https://appsembler.atlassian.net/browse/RED-1702