### PR TITLE
Fix handling when general course data has null metrics

### DIFF
--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -300,6 +300,15 @@ class GeneralCourseDataSerializer(serializers.Serializer):
             return []
 
     def get_metrics(self, obj):
+        """
+        Will return None if there is not a CourseDailyMetrics model
+
+        This will happen for courses that are created after the last daily
+        pipeline ran
+
+        TODO:  Add unit tests for this and decide if we want to continue to
+        return None or if we return "zero" data
+        """
         qs = CourseDailyMetrics.objects.filter(course_id=str(obj.id))
         if qs:
             return CourseDailyMetricsSerializer(qs.order_by('-date_for')[0]).data

--- a/frontend/src/views/CoursesList.js
+++ b/frontend/src/views/CoursesList.js
@@ -113,6 +113,16 @@ class CoursesList extends Component {
   render() {
 
     const listItems = this.state.coursesList.map((course, index) => {
+      var metrics_enrollment_count = 'N/A';
+      var metrics_num_learners_completed = 'N/A';
+      if (course.hasOwnProperty('metrics') && course['metrics'] ) {
+        if (course['metrics'].hasOwnProperty('enrollment_count')) {
+          metrics_enrollment_count = course['metrics']['enrollment_count'];
+        }
+        if (course['metrics'].hasOwnProperty('num_learners_completed')) {
+          metrics_num_learners_completed = course['metrics']['num_learners_completed'];
+        }
+      }
       return (
         <li key={course['id']} className={styles['course-list-item']}>
           <div className={styles['course-name']}>
@@ -166,7 +176,7 @@ class CoursesList extends Component {
                 Enrolments:
               </div>
               <div className={styles['mobile-value']}>
-                {course['metrics']['enrollment_count']}
+                {metrics_enrollment_count}
               </div>
             </div>
           </div>
@@ -176,7 +186,7 @@ class CoursesList extends Component {
                 Completions:
               </div>
               <div className={styles['mobile-value']}>
-                {course['metrics']['num_learners_completed']}
+                {metrics_num_learners_completed}
               </div>
             </div>
           </div>


### PR DESCRIPTION
When a course is created after the last daily pipline then there is not
a CourseDailyMetrics record for the course. This then causes the
'courses/general' API endpoint to have `null` for the 'metrics' key.

This commit is one way to address that. What it does is in the client's
courses page check if there is a value for metrics and set the values to
'N/A' if the value is not there.

There are other solutions, such as provide default '0' values in the
metrics code. But this way, we know that there are not metrics values
instead of metrics collected with zero value, which gives some clue that
there is an issue that needs to be investigated