### PR TITLE
Fix bug and Improve error handling in Figures tasks and pipeline

### DIFF
--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -67,7 +67,7 @@ def backfill_enrollment_data_for_site(site):
             enrollment_data.append((obj, created))
         except CourseNotFound:
             errors.append('CourseNotFound for course "{}". '
-                          ' CourseEnrollment ID='.format(str(rec.course_id,
-                                                         rec.id)))
+                          ' CourseEnrollment ID='.format(str(rec.course_id),
+                                                         rec.id))
 
     return dict(results=enrollment_data, errors=errors)

--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -66,8 +66,9 @@ def backfill_enrollment_data_for_site(site):
                 course_id=rec.course_id)
             enrollment_data.append((obj, created))
         except CourseNotFound:
-            errors.append('CourseNotFound for course "{}". '
-                          ' CourseEnrollment ID='.format(str(rec.course_id),
-                                                         rec.id))
+            msg = ('CourseNotFound for course "{course}". '
+                   ' CourseEnrollment ID={ce_id}')
+            errors.append(msg.format(course=str(rec.course_id),
+                                     ce_id=rec.id))
 
     return dict(results=enrollment_data, errors=errors)

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -273,7 +273,7 @@ class CourseDailyMetricsExtractor(object):
             progress_data = bulk_calculate_course_progress_data(course_id=course_id,
                                                                 date_for=date_for)
             data['average_progress'] = progress_data['average_progress']
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             # Broad exception for starters. Refine as we see what gets caught
             # Make sure we set the average_progres to None so that upstream
             # does not think things are normal

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -13,6 +13,7 @@ from celery import chord
 from celery.app import shared_task
 from celery.utils.log import get_task_logger
 
+# TODO: import CourseOverview from figures.compat
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=import-error
 from student.models import CourseEnrollment  # pylint: disable=import-error
 
@@ -43,6 +44,8 @@ logger = get_task_logger(__name__)
 @shared_task
 def populate_single_cdm(course_id, date_for=None, force_update=False):
     '''Populates a CourseDailyMetrics record for the given date and course
+
+    TODO: cdm needs to handle course_id as the string
     '''
     if date_for:
         date_for = as_date(date_for)
@@ -93,6 +96,10 @@ def update_enrollment_data(site_id, **_kwargs):
         logger.error(
             'figurs.tasks.update_enrollment_data: site_id={} does not exist'.format(
                 site_id))
+    except Exception:
+        msg = ('FIGURES:FAIL daily metrics:update_enrollment_data'
+               ' for site_id={}'.format(site_id))
+        logger.exception(msg)
 
 
 @shared_task
@@ -124,42 +131,51 @@ def populate_daily_metrics(date_for=None, force_update=False):
 
     sites_count = Site.objects.count()
     for i, site in enumerate(Site.objects.all()):
-        for course in figures.sites.get_courses_for_site(site):
+        try:
+            for course in figures.sites.get_courses_for_site(site):
+                try:
+                    populate_single_cdm(
+                        course_id=course.id,
+                        date_for=date_for,
+                        force_update=force_update)
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.exception('figures.tasks.populate_daily_metrics failed')
+                    # Always capture CDM load exceptions to the Figures pipeline
+                    # error table
+                    error_data = dict(
+                        date_for=date_for,
+                        msg='figures.tasks.populate_daily_metrics failed',
+                        exception_class=e.__class__.__name__,
+                        )
+                    if hasattr(e, 'message_dict'):
+                        error_data['message_dict'] = e.message_dict  # pylint: disable=no-member
+                    log_error_to_db(
+                        error_data=error_data,
+                        error_type=PipelineError.COURSE_DATA,
+                        course_id=str(course.id),
+                        site=site,
+                        logger=logger,
+                        log_pipeline_errors_to_db=True,
+                        )
+            populate_site_daily_metrics(
+                site_id=site.id,
+                date_for=date_for,
+                force_update=force_update)
+
+            # Until we implement signal triggers
             try:
-                populate_single_cdm(
-                    course_id=course.id,
-                    date_for=date_for,
-                    force_update=force_update)
-            except Exception as e:  # pylint: disable=broad-except
-                logger.exception('figures.tasks.populate_daily_metrics failed')
-                # Always capture CDM load exceptions to the Figures pipeline
-                # error table
-                error_data = dict(
-                    date_for=date_for,
-                    msg='figures.tasks.populate_daily_metrics failed',
-                    exception_class=e.__class__.__name__,
-                    )
-                if hasattr(e, 'message_dict'):
-                    error_data['message_dict'] = e.message_dict  # pylint: disable=no-member
-                log_error_to_db(
-                    error_data=error_data,
-                    error_type=PipelineError.COURSE_DATA,
-                    course_id=str(course.id),
-                    site=site,
-                    logger=logger,
-                    log_pipeline_errors_to_db=True,
-                    )
-        populate_site_daily_metrics(
-            site_id=site.id,
-            date_for=date_for,
-            force_update=force_update)
+                update_enrollment_data(site_id=site.id)
+            except Exception:
+                msg = ('FIGURES:FAIL figures.tasks update_enrollment_data '
+                       ' unhandled exception. site[{}]:{}')
+                logger.exception(msg.format(site.id, site.domain))
 
-        # Until we implement signal triggers
-        update_enrollment_data(site_id=site.id)
-
+        except Exception:
+            msg = ('FIGURES:FAIL populate_daily_metrics unhandled site level'
+                   ' exception for site[{}]={}')
+            logger.exception(msg.format(site.id, site.domain))
         logger.info("figures.populate_daily_metrics: finished Site {:04d} of {:04d}".format(
             i, sites_count))
-
     logger.info('Finished task "figures.populate_daily_metrics" for date "{}"'.format(
         date_for))
 

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -96,7 +96,7 @@ def update_enrollment_data(site_id, **_kwargs):
         logger.error(
             'figurs.tasks.update_enrollment_data: site_id={} does not exist'.format(
                 site_id))
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         msg = ('FIGURES:FAIL daily metrics:update_enrollment_data'
                ' for site_id={}'.format(site_id))
         logger.exception(msg)
@@ -165,12 +165,12 @@ def populate_daily_metrics(date_for=None, force_update=False):
             # Until we implement signal triggers
             try:
                 update_enrollment_data(site_id=site.id)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 msg = ('FIGURES:FAIL figures.tasks update_enrollment_data '
                        ' unhandled exception. site[{}]:{}')
                 logger.exception(msg.format(site.id, site.domain))
 
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             msg = ('FIGURES:FAIL populate_daily_metrics unhandled site level'
                    ' exception for site[{}]={}')
             logger.exception(msg.format(site.id, site.domain))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='Figures',
-    version='0.4.dev5',
+    version='0.4.dev6',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',

--- a/tests/pipeline/test_course_daily_metrics.py
+++ b/tests/pipeline/test_course_daily_metrics.py
@@ -247,6 +247,25 @@ class TestCourseDailyMetricsExtractor(object):
         results = pipeline_cdm.CourseDailyMetricsExtractor().extract(course_id)
         assert results
 
+    def test_when_bulk_calculate_course_progress_data_fails(self,
+                                                            monkeypatch,
+                                                            caplog):
+        course_id = self.course_enrollments[0].course_id
+
+        def mock_bulk(**_kwargs):
+            raise Exception('fake exception')
+
+        monkeypatch.setattr(figures.pipeline.course_daily_metrics,
+                            'bulk_calculate_course_progress_data',
+                            mock_bulk)
+
+        results = pipeline_cdm.CourseDailyMetricsExtractor().extract(course_id)
+
+        last_log = caplog.records[-1]
+        assert last_log.message.startswith(
+            'FIGURES:FAIL bulk_calculate_course_progress_data')
+        assert not results['average_progress']
+
 
 @pytest.mark.django_db
 class TestCourseDailyMetricsLoader(object):


### PR DESCRIPTION

1. Fixed the bug, poorly placed parentheses within exception handling in the new code


2. Add pipeline exception handling - course daily metrics

The pipeline function, bulk_calculate_course_progress_data, does a lot
of work and a potential point of failure to fail all the metrics for the
course for the day on collecting just one metric.

So this commit traps for exceptions when the function
"bulk_calculate_course_progress_data" is called and sets the course daily
metrics 'average_progress' to None if it fails. Being 'None' helps
identify pipeline erors rather than setting progress to zero.

Added test to make sure we are logging when it fails


3. Add figures.tasks exception handling cdm and enrollment data
Added exception handling and logging to populate_single_cdm, the call to
update_enrollment_data in 'populate_daily_metrics' and exception
handling for each site so that one site does not fail the remaining
sites in the chain

* Updated tests to handle when update_enrollment_data raises an exception
* Updated tests to handle when a site level exception is raised

https://appsembler.atlassian.net/browse/RED-1709
