### PR TITLE
Refactor: Moved a number of edx-platform imports to figures.compat

### DIFF
--- a/figures/compat.py
+++ b/figures/compat.py
@@ -1,7 +1,9 @@
 """Figures compatability module
 
-This module serves to provide a common access point to functionality that
-differs from  different named Open edX releases
+This module serves to provide a common access point to edx-platform objects.
+
+It was originally intended to encapsulate functionality that differs from
+different named Open edX releases
 
 We can identify the Open edX named release for Ginkgo and later by getting the
 value from openedx.core.release.RELEASE_LINE. This will be the release name as
@@ -74,7 +76,8 @@ else:  # Assume Hawthorn or greater
 # preemptive addition. Added it here to avoid adding to figures.models
 # In fact, we should probably do a refactoring that makes all Figures import it
 # from here
-from student.models import CourseEnrollment  # noqa pylint: disable=unused-import,import-error
+from student.models import CourseAccessRole, CourseEnrollment  # noqa pylint: disable=unused-import,import-error
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=unused-import,import-error
 
 
 def course_grade(learner, course):

--- a/figures/filters.py
+++ b/figures/filters.py
@@ -27,10 +27,7 @@ import django_filters
 
 from opaque_keys.edx.keys import CourseKey
 
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=import-error
-
-from student.models import CourseEnrollment  # pylint: disable=import-error
-
+from figures.compat import CourseEnrollment, CourseOverview
 from figures.pipeline.course_daily_metrics import get_enrolled_in_exclude_admins
 from figures.models import (
     CourseDailyMetrics,

--- a/figures/models.py
+++ b/figures/models.py
@@ -116,6 +116,8 @@ class SiteDailyMetrics(TimeStampedModel):
     # Should change this to default value of 0
     mau = models.IntegerField(blank=True, null=True)
 
+    # TODO: Add field for number of CDMs reported
+
     class Meta:
         """
         SiteDailyMetrics view and serializer tests fail when we include 'site'

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -19,11 +19,12 @@ import logging
 from django.db import transaction
 from django.utils.timezone import utc
 
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=import-error
-from student.models import CourseEnrollment  # pylint: disable=import-error
 from student.roles import CourseCcxCoachRole, CourseInstructorRole, CourseStaffRole  # noqa pylint: disable=import-error
 
-from figures.compat import GeneratedCertificate, StudentModule
+from figures.compat import (CourseEnrollment,
+                            CourseOverview,
+                            GeneratedCertificate,
+                            StudentModule)
 from figures.helpers import as_course_key, as_datetime, next_day, prev_day
 import figures.metrics
 from figures.models import CourseDailyMetrics, PipelineError

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -27,12 +27,13 @@ from django_countries import Countries
 from rest_framework import serializers
 from rest_framework.fields import empty
 
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=import-error
 from openedx.core.djangoapps.user_api.accounts.serializers import AccountLegacyProfileSerializer  # noqa pylint: disable=import-error
 
-from student.models import CourseAccessRole, CourseEnrollment  # pylint: disable=import-error
-
-from figures.compat import RELEASE_LINE, GeneratedCertificate
+from figures.compat import (RELEASE_LINE,
+                            CourseAccessRole,
+                            CourseEnrollment,
+                            CourseOverview,
+                            GeneratedCertificate)
 from figures.helpers import as_course_key
 from figures.metrics import (
     get_course_enrolled_users_for_time_period,

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import
 import datetime
 import time
 
+import six
+
 from django.contrib.sites.models import Site
 from django.utils.timezone import utc
 
@@ -13,11 +15,8 @@ from celery import chord
 from celery.app import shared_task
 from celery.utils.log import get_task_logger
 
-# TODO: import CourseOverview from figures.compat
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=import-error
-from student.models import CourseEnrollment  # pylint: disable=import-error
-
 from figures.backfill import backfill_enrollment_data_for_site
+from figures.compat import CourseEnrollment, CourseOverview
 from figures.helpers import as_course_key, as_date
 from figures.log import log_exec_time
 from figures.models import PipelineError
@@ -27,7 +26,6 @@ import figures.sites
 from figures.pipeline.mau_pipeline import collect_course_mau
 from figures.pipeline.site_monthly_metrics import fill_last_month as fill_last_smm_month
 from figures.pipeline.logger import log_error_to_db
-import six
 
 
 logger = get_task_logger(__name__)

--- a/figures/views.py
+++ b/figures/views.py
@@ -39,11 +39,7 @@ except ImportError:
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-# Directly including edx-platform objects for early development
-# Follow-on, we'll likely consolidate edx-platform model imports to an adapter
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=import-error
-
-from figures.compat import CourseEnrollment
+from figures.compat import CourseEnrollment, CourseOverview
 from figures.filters import (
     CourseDailyMetricsFilter,
     CourseEnrollmentFilter,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='Figures',
-    version='0.4.dev6',
+    version='0.4.dev7',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',

--- a/tests/pipeline/test_course_daily_metrics.py
+++ b/tests/pipeline/test_course_daily_metrics.py
@@ -10,10 +10,8 @@ import pytest
 
 from django.core.exceptions import PermissionDenied, ValidationError
 
-from student.models import CourseEnrollment, CourseAccessRole
-
+from figures.compat import CourseAccessRole, CourseEnrollment
 from figures.helpers import as_datetime, next_day, prev_day
-
 from figures.models import CourseDailyMetrics, PipelineError
 from figures.pipeline import course_daily_metrics as pipeline_cdm
 import figures.sites

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -34,9 +34,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.test import TestCase
 
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from student.models import CourseEnrollment
-
+from figures.compat import CourseEnrollment, CourseOverview
 from figures.filters import (
     CourseDailyMetricsFilter,
     CourseEnrollmentFilter,

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -15,8 +15,7 @@ from django.db import models
 from django.utils.timezone import utc
 from rest_framework.exceptions import ValidationError
 
-from student.models import CourseEnrollment
-
+from figures.compat import CourseEnrollment
 from figures.models import (
     CourseDailyMetrics,
     CourseMauMetrics,

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -31,10 +31,7 @@ from django.contrib.sites.models import Site
 
 import organizations
 
-from openedx.core.djangoapps.content.course_overviews.models import (
-    CourseOverview,
-)
-
+from figures.compat import CourseOverview
 import figures.helpers
 import figures.sites
 

--- a/tests/views/test_course_enrollment_view.py
+++ b/tests/views/test_course_enrollment_view.py
@@ -14,8 +14,7 @@ from rest_framework.test import (
 
 from opaque_keys.edx.keys import CourseKey
 
-from student.models import CourseEnrollment
-
+from figures.compat import CourseEnrollment
 from figures.helpers import is_multisite
 from figures.views import CourseEnrollmentViewSet
 

--- a/tests/views/test_general_course_data_view.py
+++ b/tests/views/test_general_course_data_view.py
@@ -7,19 +7,13 @@ from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.db.models import F
 
-
-
 from rest_framework.test import (
     APIRequestFactory,
     #RequestsClient, Not supported in older  rest_framework versions
     force_authenticate,
     )
 
-from openedx.core.djangoapps.content.course_overviews.models import (
-    CourseOverview,
-)
-from student.models import CourseEnrollment
-
+from figures.compat import CourseEnrollment, CourseOverview
 import figures.helpers
 from figures.helpers import as_course_key, is_multisite
 from figures.views import GeneralCourseDataViewSet

--- a/tests/views/test_general_user_data_view.py
+++ b/tests/views/test_general_user_data_view.py
@@ -41,8 +41,7 @@ from rest_framework.test import (
     force_authenticate,
     )
 
-from student.models import CourseEnrollment
-
+from figures.compat import CourseEnrollment
 from figures.helpers import is_multisite
 from figures.views import GeneralUserDataViewSet
 

--- a/tests/views/test_learner_details_view.py
+++ b/tests/views/test_learner_details_view.py
@@ -1,4 +1,4 @@
-'''Tests Figures UserIndexView class
+"""Tests Figures UserIndexView class
 
 TODO: make reasonable endpoint
 
@@ -27,7 +27,7 @@ Front end expects data to be returned in the following form:
 ]
 
 
-'''
+"""
 
 from __future__ import absolute_import
 import mock
@@ -42,8 +42,7 @@ from rest_framework.test import (
     force_authenticate,
     )
 
-from student.models import CourseEnrollment
-
+from figures.compat import CourseEnrollment
 from figures.helpers import as_course_key
 from figures.serializers import LearnerCourseDetailsSerializer
 from figures.sites import get_course_enrollments_for_site


### PR DESCRIPTION
Improved abstraction: This commit refactors how Figures imports edx-platform classes. It centralizes imports to figures.compat. The rest of Figures then imports the platform classes from figures.compat.

This is preliminary work to help abstract platform dependencies for Open edX named release structures and improve future testing efforts

Also bumped Figures release version to 0.4.dev7