### PR TITLE
Figures sites and pipeline fixes

### DIFF
--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -25,7 +25,7 @@ from figures.compat import (CourseEnrollment,
                             CourseOverview,
                             GeneratedCertificate,
                             StudentModule)
-from figures.helpers import as_course_key, as_datetime, next_day, prev_day
+from figures.helpers import as_course_key, as_date, as_datetime, next_day, prev_day
 import figures.metrics
 from figures.models import CourseDailyMetrics, PipelineError
 from figures.pipeline.logger import log_error
@@ -345,10 +345,13 @@ class CourseDailyMetricsLoader(object):
         course daily metrics model instance
         """
         if not date_for:
+            # Figures works in UTC
             date_for = prev_day(
-                datetime.datetime.utcnow().replace(tzinfo=utc).date())
+                datetime.datetime.utcnow().replace(tzinfo=utc))
         else:
-            date_for = as_datetime(date_for).replace(tzinfo=utc)
+            # Needs to be a date object and not a datetime
+            # TODO: Add timezone test coverage
+            date_for = as_date(date_for)
         try:
             cdm = CourseDailyMetrics.objects.get(course_id=self.course_id,
                                                  date_for=date_for)

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -12,12 +12,10 @@ Future: add a remote mode to pull data via REST API
 # TODO: Move extractors to figures.pipeline.extract module
 """
 from __future__ import absolute_import
-import datetime
 from decimal import Decimal
 import logging
 
 from django.db import transaction
-from django.utils.timezone import utc
 
 from student.roles import CourseCcxCoachRole, CourseInstructorRole, CourseStaffRole  # noqa pylint: disable=import-error
 
@@ -25,7 +23,7 @@ from figures.compat import (CourseEnrollment,
                             CourseOverview,
                             GeneratedCertificate,
                             StudentModule)
-from figures.helpers import as_course_key, as_date, as_datetime, next_day, prev_day
+from figures.helpers import as_course_key, as_datetime, next_day
 import figures.metrics
 from figures.models import CourseDailyMetrics, PipelineError
 from figures.pipeline.logger import log_error
@@ -33,6 +31,7 @@ import figures.pipeline.loaders
 from figures.pipeline.enrollment_metrics import bulk_calculate_course_progress_data
 from figures.serializers import CourseIndexSerializer
 import figures.sites
+from figures.pipeline.helpers import pipeline_date_for_rule
 
 
 logger = logging.getLogger(__name__)
@@ -226,7 +225,7 @@ class CourseDailyMetricsExtractor(object):
     BUT, we will then need to find a transform
     """
 
-    def extract(self, course_id, date_for=None, **_kwargs):
+    def extract(self, course_id, date_for, **_kwargs):
         """
             defaults = dict(
                 enrollment_count=data['enrollment_count'],
@@ -239,12 +238,6 @@ class CourseDailyMetricsExtractor(object):
         Add lazy loading method to load course enrollments
         - Create a method for each metric field
         """
-
-        # Update args if not assigned
-        if not date_for:
-            date_for = prev_day(
-                datetime.datetime.utcnow().replace(tzinfo=utc).date()
-            )
 
         # We can turn this series of calls into a parallel
         # set of calls defined in a ruleset instead of hardcoded here after
@@ -344,14 +337,7 @@ class CourseDailyMetricsLoader(object):
         Raises ValidationError if invalid data is attempted to be saved to the
         course daily metrics model instance
         """
-        if not date_for:
-            # Figures works in UTC
-            date_for = prev_day(
-                datetime.datetime.utcnow().replace(tzinfo=utc))
-        else:
-            # Needs to be a date object and not a datetime
-            # TODO: Add timezone test coverage
-            date_for = as_date(date_for)
+        date_for = pipeline_date_for_rule(date_for)
         try:
             cdm = CourseDailyMetrics.objects.get(course_id=self.course_id,
                                                  date_for=date_for)

--- a/figures/pipeline/enrollment_metrics.py
+++ b/figures/pipeline/enrollment_metrics.py
@@ -49,18 +49,18 @@ for each learner+course  # See bulk_calculate_course_progress_data
 from __future__ import absolute_import
 from datetime import datetime
 from decimal import Decimal
+import logging
 
 from django.utils.timezone import utc
 
 from figures.metrics import LearnerCourseGrades
-from figures.models import LearnerCourseGradeMetrics, PipelineError
-from figures.pipeline.logger import log_error
-from figures.sites import (
-    get_site_for_course,
-    get_student_modules_for_course_in_site,
-    course_enrollments_for_course,
-    UnlinkedCourseError,
-    )
+from figures.models import LearnerCourseGradeMetrics
+from figures.sites import (get_site_for_course,
+                           course_enrollments_for_course,
+                           student_modules_for_course_enrollment,
+                           UnlinkedCourseError)
+
+logger = logging.getLogger(__name__)
 
 
 def bulk_calculate_course_progress_data(course_id, date_for=None):
@@ -68,7 +68,7 @@ def bulk_calculate_course_progress_data(course_id, date_for=None):
 
     How it works
     1. collects progress percent for each course enrollment
-        1.1. If up to date enrollment metrics record already exists, use that
+        1.1. If an up to date enrollment metrics record already exists, use that
     2. calculate and return the average of these enrollments
 
     TODO: Update to filter on active users
@@ -78,7 +78,6 @@ def bulk_calculate_course_progress_data(course_id, date_for=None):
 
     """
     progress_percentages = []
-
     if not date_for:
         date_for = datetime.utcnow().replace(tzinfo=utc).date()
 
@@ -86,28 +85,21 @@ def bulk_calculate_course_progress_data(course_id, date_for=None):
     if not site:
         raise UnlinkedCourseError('No site found for course "{}"'.format(course_id))
 
-    course_sm = get_student_modules_for_course_in_site(site=site,
-                                                       course_id=course_id)
+    # We might be able to make this more efficient by finding only the learners
+    # in the course with StudentModule (SM) records then get their course
+    # enrollment (CE) records as we can ignore any learners without SM records
+    # since that means they don't have any course progress
     for ce in course_enrollments_for_course(course_id):
-        metrics = collect_metrics_for_enrollment(site=site,
-                                                 course_enrollment=ce,
-                                                 course_sm=course_sm,
-                                                 date_for=date_for)
-        if metrics:
-            progress_percentages.append(metrics.progress_percent)
-        else:
-            # Log this for troubleshooting
-            error_data = dict(
-                msg=('Unable to create or retrieve enrollment metrics ' +
-                     'for user {} and course {}'.format(ce.user.username,
-                                                        str(ce.course_id)))
-            )
-            log_error(
-                error_data=error_data,
-                error_type=PipelineError.COURSE_DATA,
-                user=ce.user,
-                course_id=str(course_id)
-            )
+        sm = student_modules_for_course_enrollment(
+            site=site,
+            course_enrollment=ce).order_by('-modified')
+        if sm:
+            metrics = collect_metrics_for_enrollment(site=site,
+                                                     course_enrollment=ce,
+                                                     date_for=date_for,
+                                                     student_modules=sm)
+            if metrics:
+                progress_percentages.append(metrics.progress_percent)
 
     return dict(
         average_progress=calculate_average_progress(progress_percentages),
@@ -129,17 +121,30 @@ def calculate_average_progress(progress_percentages):
     return average_progress
 
 
-def collect_metrics_for_enrollment(site, course_enrollment, course_sm, date_for=None):
+def collect_metrics_for_enrollment(site, course_enrollment, date_for, student_modules=None):
     """Collect metrics for enrollment (learner+course)
+
+    NOTE: We pass in the student_modules for the learner to save excution time
+    However, there is the issue that the caller could pass them in out of proper order
+    Therefore we will revisit if we really need to open this up for error or
+    if we can accept calling the query twice for the sake of data integrity.
+
+    One compromise is to implement a "most recent sm function in sites"
+    Eventually (and maybe sooner rather than later), this concern should go
+    away as we move toward live data capture into Figures 'EnrollmentData' and
+    the succcessor to LearnerCourseGradeMetrics to snapshot learner progress
+    over time (either live capture or frequent scheduled snapshot checks)
 
     This function performs course enrollment merics collection for the given
     unique enrollment identified by the learner and course. It is initial code
     in refactoring the pipeline for learner progress
 
     Important models here are:
-    * StudentModule (SM)
-    * LearnerCourseGradeMetrics (LCGM)
-    * CourseEnrollment (CE)
+    * Platform models:
+        * CourseEnrollment (CE)
+        * StudentModule (SM)
+    * Figures models:
+        * LearnerCourseGradeMetrics (LCGM)
 
     # Workflow
 
@@ -153,26 +158,38 @@ def collect_metrics_for_enrollment(site, course_enrollment, course_sm, date_for=
     * else return the existing LearnerCourseGradesMetics record if it exists
     * else return None if no existing LearnerCourseGradesMetics record
     """
-    if not date_for:
-        date_for = datetime.utcnow().replace(tzinfo=utc).date()
 
     # The following are two different ways to avoide the dreaded error
     #     "Instance of 'list' has no 'order_by' member (no-member)"
     # See: https://github.com/PyCQA/pylint-django/issues/165
-    student_modules = course_sm.filter(
-        student_id=course_enrollment.user.id).order_by('-modified')
-    if student_modules:
-        most_recent_sm = student_modules[0]
-    else:
-        most_recent_sm = None
 
-    lcgm = LearnerCourseGradeMetrics.objects.filter(
+    if not student_modules:
+        student_modules = student_modules_for_course_enrollment(
+            site=site,
+            course_enrollment=course_enrollment).order_by('-modified')
+
+    # check if there are any StudentModule records for the enrollment
+    # if not, no progress to report
+
+    # If there are no student module records, then the learner had no activity
+    # in this course, so we return None
+    if not student_modules:
+        return None
+
+    most_recent_sm = student_modules[0]
+    most_recent_lcgm = LearnerCourseGradeMetrics.objects.latest_lcgm(
         user=course_enrollment.user,
-        course_id=str(course_enrollment.course_id))
-    most_recent_lcgm = lcgm.order_by('date_for').last()
+        course_id=course_enrollment.course_id)
 
     if _enrollment_metrics_needs_update(most_recent_lcgm, most_recent_sm):
         progress_data = _collect_progress_data(most_recent_sm)
+        # When the pipeline gets interrupted there can be a state where there
+        # are LCGM records for the 'date_for'
+        # The 'date_for' is is yesterday in normal operation.
+        #
+        # TODO: Handle this. It can cause an 'IntegrityError' 1062 (a MySQL error)
+        # "Duplicate entry '<user_id>-<course_id><date_for>' for key
+        # '<table_name>_user_id_<hash>_uniq'"
         metrics = _new_enrollment_metrics_record(site=site,
                                                  course_enrollment=course_enrollment,
                                                  progress_data=progress_data,
@@ -230,33 +247,19 @@ def _enrollment_metrics_needs_update(most_recent_lcgm, most_recent_sm):
         needs_update = True
     elif most_recent_lcgm and not most_recent_sm:
         # This shouldn't happen. We log this state as an error
-
-        # using 'COURSE_DATA' for the pipeline error type. Although we should
-        # revisit logging and error tracking in Figures to define a clear
-        # approach that has clear an intuitive contexts for the logging event
+        # This case is an artifact from before enrollment metrics were reworked.
+        # Figures used to collect an LCGM record for every enrollment every day.
+        # Now we only create a new LCGM record when there is a new or changed
+        # StudentModule record
+        # However, this condition will occur until all the "unlinked" LCGM
+        # records are deleted
         #
-        # We neede to decide:
-        #
-        # 1. Is this always an error state? Could this condition happen naturally?
-        #
-        # 2. Which error type should be created and what is the most applicable
-        #    context
-        #    Candidates
-        #    - Enrollment (learner+course) context
-        #    - Data state context - Why would we have an LCGM
-        #
-        # So we hold off updating PipelineError error choises initially until
-        # we can think carefully on how we tag pipeline errors
-        #
-        error_data = dict(
-            msg='LearnerCourseGradeMetrics record exists without StudentModule',
-        )
-        log_error(
-            error_data=error_data,
-            error_type=PipelineError.COURSE_DATA,
-            user=most_recent_lcgm.user,
-            course_id=str(most_recent_lcgm.course_id)
-        )
+        # We log
+        msg = ('FIGURES:PIPELINE:LCGM record exists without StudentModule'
+               ' lcgm_id={lcgm_id}, user_id={user_id}, course_id={course_id}')
+        logger.warning(msg.format(lcgm_id=most_recent_lcgm.id,
+                                  user_id=most_recent_lcgm.user_id,
+                                  course_id=most_recent_lcgm.course_id))
         needs_update = False
     return needs_update
 

--- a/figures/pipeline/helpers.py
+++ b/figures/pipeline/helpers.py
@@ -1,0 +1,55 @@
+"""Helper module specific to Figures pipeline
+
+The code in this module is intended specifically to run in Figures pipeline
+without consideration of running elsewhere, such as Figures API calls.
+"""
+
+from datetime import datetime
+from django.utils.timezone import utc
+from figures.helpers import as_date, prev_day
+
+
+class DateForCannotBeFutureError(Exception):
+    """Raise this if a future date is requested for pipeline processing
+    """
+    pass
+
+
+def pipeline_date_for_rule(date_for):
+    """Common logic to assign the 'date_for' date for daily pipeline processing
+
+    * If 'date_for' is 'None' or today, then this function returns a
+      'datetime.date' instance for yesterday
+    * If 'date_for' is a date in the past, this function returns the
+      'datetime.date' representation of the date
+    * If 'date_for' is in the future, then `DateForCannotBeFutureError` is
+      raised
+
+    As part of normal Figures data collection, the pipeline must collect data
+    from the previous calendar day, assuming all timestamps are UTC.
+    This is to build a complete picture of a 24 hour period.
+
+    This function exists to have this logic in a single place in the code.
+    This logic is specific to the pipeline so it belongs in Figures' pipeline
+    namespce.
+
+    We may rework this as a decorator or as part of core functionality in a
+    base class from which daily metrics classes can derive.
+    """
+    today = datetime.utcnow().replace(tzinfo=utc).date()
+    if not date_for:
+        date_for = prev_day(today)
+    else:
+        # Because we are working on the calendar day and the daily metrics
+        # models use date and not datetime for the 'date_for' fields
+        date_for = as_date(date_for)
+
+        # Either we are backfilling data (if the date is prior to yesterday)
+        # or the caller explicity requests to process for yesterday
+        if date_for > today:
+            msg = 'Attempted pipeline call with future date: "{date_for}"'
+            raise DateForCannotBeFutureError(msg.format(date_for=date_for))
+        elif date_for == today:
+            return prev_day(today)
+
+    return date_for

--- a/figures/pipeline/site_daily_metrics.py
+++ b/figures/pipeline/site_daily_metrics.py
@@ -12,7 +12,7 @@ import datetime
 from django.utils.timezone import utc
 from django.db.models import Sum
 
-from figures.helpers import as_course_key, as_datetime, next_day, prev_day
+from figures.helpers import as_course_key, as_date, as_datetime, next_day, prev_day
 from figures.mau import site_mau_1g_for_month_as_of_day
 from figures.models import CourseDailyMetrics, SiteDailyMetrics
 from figures.sites import (
@@ -165,11 +165,14 @@ class SiteDailyMetricsLoader(object):
         * Course acess groups
         '''
         if not date_for:
+            # Figures works in UTC
             date_for = prev_day(
                 datetime.datetime.utcnow().replace(tzinfo=utc).date()
             )
         else:
-            date_for = as_datetime(date_for).replace(tzinfo=utc)
+            # Needs to be a date object and not a datetime
+            # TODO: Add timezone test coverage
+            date_for = as_date(date_for)
         # if we already have a record for the date_for and force_update is False
         # then skip getting data
         if not force_update:

--- a/figures/pipeline/site_daily_metrics.py
+++ b/figures/pipeline/site_daily_metrics.py
@@ -1,18 +1,16 @@
-'''This module populates the figures.models.SiteDailyMetrics model
+"""This module populates the figures.models.SiteDailyMetrics model
 
 
 Most of the data are from CourseDailyMetrics. Some data are not captured in
 course metrics. These data are extracted directly from edx-platform models
 
-'''
+"""
 
 from __future__ import absolute_import
-import datetime
 
-from django.utils.timezone import utc
 from django.db.models import Sum
 
-from figures.helpers import as_course_key, as_date, as_datetime, next_day, prev_day
+from figures.helpers import as_course_key, as_datetime, next_day
 from figures.mau import site_mau_1g_for_month_as_of_day
 from figures.models import CourseDailyMetrics, SiteDailyMetrics
 from figures.sites import (
@@ -20,6 +18,7 @@ from figures.sites import (
     get_users_for_site,
     get_student_modules_for_site,
 )
+from figures.pipeline.helpers import pipeline_date_for_rule
 
 
 #
@@ -112,18 +111,13 @@ class SiteDailyMetricsExtractor(object):
     def __init__(self):
         pass
 
-    def extract(self, site, date_for=None, **kwargs):  # pylint: disable=unused-argument
+    def extract(self, site, date_for, **kwargs):  # pylint: disable=unused-argument
         '''
         We get the count from the User model since there can be registered users
         who have not enrolled.
 
         TODO: Exclude non-students from the user count
         '''
-        if not date_for:
-            date_for = prev_day(
-                datetime.datetime.utcnow().replace(tzinfo=utc).date()
-            )
-
         data = dict()
 
         site_users = get_users_for_site(site)
@@ -153,7 +147,7 @@ class SiteDailyMetricsLoader(object):
         self.extractor = extractor or SiteDailyMetricsExtractor()
 
     def load(self, site, date_for=None, force_update=False, **_kwargs):
-        '''
+        """
         Architectural note:
         Initially, we're going to be explicit, requiring callers to specify the
         site model instance to be associated with the site specific metrics
@@ -163,16 +157,9 @@ class SiteDailyMetricsLoader(object):
         Add filtering for
         * Multi-tenancy
         * Course acess groups
-        '''
-        if not date_for:
-            # Figures works in UTC
-            date_for = prev_day(
-                datetime.datetime.utcnow().replace(tzinfo=utc).date()
-            )
-        else:
-            # Needs to be a date object and not a datetime
-            # TODO: Add timezone test coverage
-            date_for = as_date(date_for)
+        """
+        date_for = pipeline_date_for_rule(date_for)
+
         # if we already have a record for the date_for and force_update is False
         # then skip getting data
         if not force_update:

--- a/tests/pipeline/test_course_daily_metrics.py
+++ b/tests/pipeline/test_course_daily_metrics.py
@@ -235,6 +235,7 @@ class TestCourseDailyMetricsExtractor(object):
     def setup(self, db):
         self.course_enrollments = [CourseEnrollmentFactory() for i in range(1, 5)]
         self.student_module = StudentModuleFactory()
+        self.date_for = datetime.datetime.utcnow().date()
 
     def test_extract(self, monkeypatch):
         course_id = self.course_enrollments[0].course_id
@@ -242,7 +243,8 @@ class TestCourseDailyMetricsExtractor(object):
                             'bulk_calculate_course_progress_data',
                             lambda **_kwargs: dict(average_progress=0.5))
 
-        results = pipeline_cdm.CourseDailyMetricsExtractor().extract(course_id)
+        results = pipeline_cdm.CourseDailyMetricsExtractor().extract(
+            course_id, self.date_for)
         assert results
 
     def test_when_bulk_calculate_course_progress_data_fails(self,
@@ -257,7 +259,8 @@ class TestCourseDailyMetricsExtractor(object):
                             'bulk_calculate_course_progress_data',
                             mock_bulk)
 
-        results = pipeline_cdm.CourseDailyMetricsExtractor().extract(course_id)
+        results = pipeline_cdm.CourseDailyMetricsExtractor().extract(
+            course_id, self.date_for)
 
         last_log = caplog.records[-1]
         assert last_log.message.startswith(

--- a/tests/pipeline/test_enrollment_metrics.py
+++ b/tests/pipeline/test_enrollment_metrics.py
@@ -1,12 +1,12 @@
 
 from __future__ import absolute_import
-from datetime import datetime
+from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 import mock
 import pytest
 
 from django.utils.timezone import utc
-from figures.compat import StudentModule
+from figures.compat import CourseEnrollment, StudentModule
 
 from figures.helpers import is_multisite
 from figures.models import LearnerCourseGradeMetrics
@@ -24,10 +24,17 @@ from tests.factories import (
     CourseEnrollmentFactory,
     CourseOverviewFactory,
     LearnerCourseGradeMetricsFactory,
+    OrganizationFactory,
+    OrganizationCourseFactory,
     SiteFactory,
     StudentModuleFactory,
 )
+from tests.helpers import organizations_support_sites
 from six.moves import range
+
+
+if organizations_support_sites():
+    from tests.factories import UserOrganizationMappingFactory
 
 
 @pytest.mark.django_db
@@ -47,6 +54,7 @@ def test_bulk_calculate_course_progress_data_happy_path(db, monkeypatch):
         sections_worked=1,
         sections_possible=2) for ce in course_enrollments
     }
+    StudentModuleFactory()
 
     def mock_metrics(course_enrollment, **_kwargs):
         return mapping[course_enrollment.course_id]
@@ -55,6 +63,13 @@ def test_bulk_calculate_course_progress_data_happy_path(db, monkeypatch):
                         lambda val: SiteFactory())
     monkeypatch.setattr('figures.pipeline.enrollment_metrics.collect_metrics_for_enrollment',
                         mock_metrics)
+
+    monkeypatch.setattr('figures.pipeline.enrollment_metrics.course_enrollments_for_course',
+                        lambda val: CourseEnrollment.objects.all())
+    # monkeypatch.setattr('figures.pipeline.enrollment_metrics.student_modules_for_course_enrollment',
+    #                     mock_get_student_modules)
+    monkeypatch.setattr('figures.pipeline.enrollment_metrics.student_modules_for_course_enrollment',
+                        lambda **_kwargs: StudentModule.objects.all())
     data = bulk_calculate_course_progress_data(course_overview.id)
     assert data['average_progress'] == 0.5
 
@@ -134,17 +149,39 @@ class TestCollectMetricsForEnrollment(object):
     """
     @pytest.fixture(autouse=True)
     def setup(self, db):
+        self.today = date.today()
         self.site = SiteFactory()
-        self.date_1 = datetime(2020, 2, 2, tzinfo=utc)
-        self.date_2 = self.date_1 + relativedelta(months=1)  # future of date_1
-        self.course_enrollment = CourseEnrollmentFactory()
+        if organizations_support_sites():
+            self.org = OrganizationFactory(sites=[self.site])
+        else:
+            self.org = OrganizationFactory()
+
+        self.datetime_1 = datetime(2020, 2, 2, tzinfo=utc)
+        self.datetime_2 = self.datetime_1 + relativedelta(months=1)  # future of date_1
+        self.course_overview = CourseOverviewFactory()
+        self.course_enrollment = CourseEnrollmentFactory(course_id=self.course_overview.id)
+        self.course_enrollment_2 = CourseEnrollmentFactory(course_id=self.course_overview.id)
+        if organizations_support_sites():
+            OrganizationCourseFactory(organization=self.org,
+                                      course_id=str(self.course_overview.id))
+            UserOrganizationMappingFactory(organization=self.org,
+                                           user=self.course_enrollment.user)
+            UserOrganizationMappingFactory(organization=self.org,
+                                           user=self.course_enrollment_2.user)
         self.student_modules = [
             StudentModuleFactory(student=self.course_enrollment.user,
                                  course_id=self.course_enrollment.course_id,
-                                 modified=self.date_1),
+                                 modified=self.datetime_1),
             StudentModuleFactory(student=self.course_enrollment.user,
                                  course_id=self.course_enrollment.course_id,
-                                 modified=self.date_2)]
+                                 modified=self.datetime_2),
+            # This student module does not belong to the user in course_enrollment
+            StudentModuleFactory(course_id=self.course_enrollment.course_id,
+                                 modified=self.datetime_2)
+        ]
+        self.learner_sm = StudentModule.objects.filter(
+            course_id=self.course_enrollment.course_id,
+            student=self.course_enrollment.user).order_by('-modified')
         self.progress_data = dict(points_possible=100,
                                   points_earned=25,
                                   sections_worked=4,
@@ -158,12 +195,12 @@ class TestCollectMetricsForEnrollment(object):
         assert obj.sections_worked == data['sections_worked']
         assert obj.sections_possible == data['count']
 
-    def create_lcgm(self, date_for):
+    def create_lcgm(self, date_for, course_enrollment):
         """Helper to create an LCGM record with the given `date_for`
         """
         return LearnerCourseGradeMetricsFactory(
-            course_id=str(self.course_enrollment.course_id),
-            user=self.course_enrollment.user,
+            course_id=str(course_enrollment.course_id),
+            user=course_enrollment.user,
             date_for=date_for,
             points_possible=self.progress_data['points_possible'],
             points_earned=self.progress_data['points_earned'],
@@ -171,7 +208,7 @@ class TestCollectMetricsForEnrollment(object):
             sections_possible=self.progress_data['count']
         )
 
-    def test_needs_update_no_lcgm(self, monkeypatch):
+    def test_has_no_lcgm_and_needs_update(self, monkeypatch):
         """We have an SM record, but no LCGM record
 
         The function under test should return a new LCGM record
@@ -182,37 +219,51 @@ class TestCollectMetricsForEnrollment(object):
         monkeypatch.setattr('figures.pipeline.enrollment_metrics._collect_progress_data',
                             lambda val: self.progress_data)
 
-        course_sm = StudentModule.objects.filter(course_id=self.course_enrollment.course_id)
         metrics = collect_metrics_for_enrollment(site=self.site,
                                                  course_enrollment=self.course_enrollment,
-                                                 course_sm=course_sm)
+                                                 date_for=self.today,
+                                                 student_modules=self.learner_sm)
 
         self.check_response_metrics(metrics, self.progress_data)
         assert LearnerCourseGradeMetrics.objects.count() == 1
 
-    def test_needs_update_has_lcgm(self, monkeypatch):
+    def test_has_lcgm_and_needs_update(self, monkeypatch):
         """We have an LCGM record, but it is not up to date with the SM
 
         The function under test should return a new LCGM
 
         TODO: Add test where we pass in `date_for` to the function under test
         """
-        lcgm = self.create_lcgm(date_for=self.date_1)
+        assert not LearnerCourseGradeMetrics.objects.filter(
+            user=self.course_enrollment.user,
+            course_id=str(self.course_enrollment.course_id)).exists()
+        lcgm = self.create_lcgm(date_for=self.datetime_1.date(),
+                                course_enrollment=self.course_enrollment)
+        # lcgm = LearnerCourseGradeMetricsFactory()
+        # Maybe remove these, but first make code sample to show how to mock
+        # multisite. This helps in abstracting our tests, but risks wrong
+        # behavior in production
+        # If we do monkeypatch like this, we will need to also monkeypatch the
+        # user belonging to the site
         monkeypatch.setattr('figures.pipeline.enrollment_metrics.get_site_for_course',
                             lambda val: self.site)
         monkeypatch.setattr('figures.pipeline.enrollment_metrics._collect_progress_data',
                             lambda val: self.progress_data)
-        course_sm = StudentModule.objects.filter(course_id=self.course_enrollment.course_id)
+
+        # assert isinstance(lcgm.date_for, date)
+        # import pdb; pdb.set_trace()
+        assert _enrollment_metrics_needs_update(lcgm, self.learner_sm[0])
         metrics = collect_metrics_for_enrollment(site=self.site,
                                                  course_enrollment=self.course_enrollment,
-                                                 course_sm=course_sm)
+                                                 date_for=self.today,
+                                                 student_modules=self.learner_sm)
 
         self.check_response_metrics(metrics, self.progress_data)
         assert metrics != lcgm
 
         # This works because we pick dates in the past. Better is to  fix this
         # by either using freezegun or monkeypatching `_new_enrollment_metrics_record
-        assert metrics.date_for >= self.date_2.date()
+        assert metrics.date_for >= self.datetime_2.date()
 
     def test_does_not_need_update(self, monkeypatch):
         """We have an LCGM record that is up to date with the SM
@@ -221,19 +272,21 @@ class TestCollectMetricsForEnrollment(object):
 
         TODO: Add test where we pass in `date_for` to the function under test
         """
-        lcgm = self.create_lcgm(date_for=self.date_2.date())
+        lcgm = self.create_lcgm(date_for=self.datetime_2.date(),
+                                course_enrollment=self.course_enrollment)
         monkeypatch.setattr('figures.pipeline.enrollment_metrics.get_site_for_course',
                             lambda val: self.site)
         monkeypatch.setattr('figures.pipeline.enrollment_metrics._collect_progress_data',
                             lambda val: self.progress_data)
-        course_sm = StudentModule.objects.filter(course_id=self.course_enrollment.course_id)
+
         metrics = collect_metrics_for_enrollment(site=self.site,
                                                  course_enrollment=self.course_enrollment,
-                                                 course_sm=course_sm)
+                                                 date_for=self.today,
+                                                 student_modules=self.learner_sm)
 
         self.check_response_metrics(metrics, self.progress_data)
         assert metrics == lcgm
-        assert metrics.date_for == self.date_2.date()
+        assert metrics.date_for == self.datetime_2.date()
 
     def test_no_update_no_lcgm_no_sm(self, monkeypatch):
         """We have neither an LCGM nor an SM record
@@ -245,11 +298,12 @@ class TestCollectMetricsForEnrollment(object):
         monkeypatch.setattr('figures.pipeline.enrollment_metrics._collect_progress_data',
                             lambda val: self.progress_data)
         # Create a course enrollment for which we won't have student module records
-        ce = CourseEnrollmentFactory()
-        course_sm = StudentModule.objects.filter(course_id=ce.course_id)
+        learner_sm = StudentModule.objects.filter(course_id=self.course_enrollment_2.course_id,
+                                                  student=self.course_enrollment_2.user)
         metrics = collect_metrics_for_enrollment(site=self.site,
-                                                 course_enrollment=ce,
-                                                 course_sm=course_sm)
+                                                 course_enrollment=self.course_enrollment_2,
+                                                 date_for=self.today,
+                                                 student_modules=learner_sm)
         assert not metrics
 
     def test_no_update_has_lcgm_no_sm(self, monkeypatch):
@@ -262,14 +316,27 @@ class TestCollectMetricsForEnrollment(object):
         monkeypatch.setattr('figures.pipeline.enrollment_metrics._collect_progress_data',
                             lambda val: self.progress_data)
         # Create a course enrollment for which we won't have student module records
-        ce = CourseEnrollmentFactory()
+        ce = CourseEnrollmentFactory(course_id=self.course_enrollment.course_id)
+        if organizations_support_sites():
+            UserOrganizationMappingFactory(organization=self.org, user=ce.user)
         lcgm = LearnerCourseGradeMetricsFactory(course_id=ce.course_id, user=ce.user)
-        course_sm = StudentModule.objects.filter(course_id=ce.course_id)
+        
+        ce_sm = StudentModule.objects.filter(course_id=ce.course_id, student_id=ce.user.id)
+        assert not ce_sm
         metrics = collect_metrics_for_enrollment(site=self.site,
                                                  course_enrollment=ce,
-                                                 course_sm=course_sm)
-        assert metrics == lcgm
-        assert not StudentModule.objects.filter(course_id=ce.course_id)
+                                                 date_for=self.today,
+                                                 student_modules=ce_sm)
+        assert not metrics
+        # assert not StudentModule.objects.filter(course_id=ce.course_id)
+
+    def test_arg_sm_acts_as_no_arg_sm(self):
+        """
+        Test that we get the same results if we don't pass a student_module arg
+        as when we do for the same set of student module records for the
+        course enrollment
+        """
+        pass
 
 
 @pytest.mark.django_db
@@ -296,11 +363,16 @@ class TestEnrollmentMetricsUpdateCheck(object):
     def test_existence_no_lcgm_yes_sm_is_true(self):
         assert _enrollment_metrics_needs_update(None, self.student_module)
 
-    def test_existence_yes_lcgm_no_sm_is_false(self):
-        path = 'figures.pipeline.enrollment_metrics.log_error'
-        with mock.patch(path) as mock_log_error:
-            assert not _enrollment_metrics_needs_update(LearnerCourseGradeMetricsFactory(), None)
-            mock_log_error.assert_called()
+    def test_existence_yes_lcgm_no_sm_is_false(self, caplog):
+        lcgm = LearnerCourseGradeMetricsFactory()
+        assert not _enrollment_metrics_needs_update(lcgm, None)
+        last_log = caplog.records[-1]
+        assert last_log.message.startswith('FIGURES:PIPELINE:LCGM')
+        # import pdb; pdb.set_trace()
+        assert lcgm.course_id in last_log.message
+        assert str(lcgm.id) in last_log.message
+        assert str(lcgm.user.id) in last_log.message
+
 
     def test_dates_lcgm_is_current_is_false(self):
         lcgm = LearnerCourseGradeMetricsFactory(

--- a/tests/pipeline/test_helpers.py
+++ b/tests/pipeline/test_helpers.py
@@ -1,0 +1,72 @@
+"""Test Figures pipeline.helpers module
+
+This module tests the helper code in `figures.pipeline.helpers`. The code in
+that module is intended specifically to run in Figures pipeline without
+consideration of running elsewhere, such as Figures API calls
+
+# Engineering note on testing 'pipeline_date_for_rule'
+
+We test using the current datetime instead of mockig a fixed datetime to
+simulate 'now' primarily because timezone handling is tricky and we want to
+mask a bug if the 'utcnow' mocking doesn't handle it correctly
+"""
+
+from datetime import datetime, date, timedelta
+import pytest
+
+from django.utils.timezone import utc
+from figures.pipeline.helpers import (DateForCannotBeFutureError,
+                                      pipeline_date_for_rule)
+from figures.helpers import as_date
+
+
+def test_pipeline_date_for_rule_get_yesterday_with_none():
+    """Ensure function under test returns yesterday as a datetime.date instance
+    """
+    now = datetime.utcnow().replace(tzinfo=utc)
+    date_for = pipeline_date_for_rule(None)
+    assert isinstance(date_for, date)
+    assert date_for == now.date() - timedelta(days=1)
+
+
+def run_pipeline_date_for_rule_asserts(arg_datetime, expected_date):
+    """Validate function works with different parameter types
+    """
+    assert pipeline_date_for_rule(arg_datetime) == expected_date
+    # test as date
+    assert pipeline_date_for_rule(arg_datetime.date()) == expected_date
+    # test as string rep of datetime
+    assert pipeline_date_for_rule(str(arg_datetime)) == expected_date
+    # test as string rep of date
+    assert pipeline_date_for_rule(str(arg_datetime.date())) == expected_date
+
+
+@pytest.mark.parametrize('day_from_now', [-1, 0])
+def test_pipeline_date_for_rule_get_yesterday(day_from_now):
+    """Ensure function under test returns yesterday as a datetime.date instance
+    """
+    now = datetime.utcnow().replace(tzinfo=utc)
+    arg_datetime = now + timedelta(days=day_from_now)
+    expected_date = (now - timedelta(days=1)).date()
+    run_pipeline_date_for_rule_asserts(arg_datetime, expected_date)
+
+
+@pytest.mark.parametrize('days_in_past', [1, 2, 3, 10, 999])
+def test_pipeline_date_for_rule_get_date_in_past(days_in_past):
+    """Ensure function  under test returns a date instance of the arg date
+    """
+    arg_datetime = datetime.utcnow().replace(tzinfo=utc) - timedelta(
+        days=days_in_past)
+    expected_date = as_date(arg_datetime)
+    run_pipeline_date_for_rule_asserts(arg_datetime, expected_date)
+
+
+@pytest.mark.parametrize('days_in_future', [1, 2, 10, 999])
+def test_pipeline_data_for_rule_raises_future_exception(days_in_future):
+    """Ensure function under test raises DateForCannotBeFutureError for future
+    dates
+    """
+    arg_date = datetime.utcnow().replace(tzinfo=utc) + timedelta(
+        days=days_in_future)
+    with pytest.raises(DateForCannotBeFutureError):
+        pipeline_date_for_rule(arg_date)


### PR DESCRIPTION
Fixed Figures sites - Some functions would not work in standalone

Fixed date/datetime type in site and course daily metrics pipeline
loaders. The problem was that the loaders would filter for existing
records using a datetime where the 'date_for' field is a date field.
Using a datetime caused the date to check the previous day in the
queryset filter

Fixed logic in the enrollment metrics pipeline. The enrollment metrics
pipeline code was causing massive noise in the logs. The key change is
in working with the StudentModule records. Records are filtered now per
enrollment instead of per course and if there are no StudentModule
records then the call returns back to the caller without running a query
for the LearnerCourseGradeMetrics records for th enrollment

Reworked the logging in enrollment_metrics so that if an LCGM record is
found for the enrollment without any StudentModule records, then a
warning is logged with the specific prefix 'FIGURES:PIPELINE:LCGM' and
the LCGM record id as well as the user id and course id. This will help
with easily grepping the log files to aid in safe cleanup of LCGM
records without deleting history.

While reworking the logging, also changed code to only log to the Python
logger instead of Figures 'PipelineError' model as we overhaul logging

Added some light test coverage for the changes, but still needs more