### PR TITLE
get_sites: configurable backend to filter active sites

### DIFF
--- a/devsite/devsite/seed.py
+++ b/devsite/devsite/seed.py
@@ -412,7 +412,7 @@ def hotwire_multisite():
 
 def backfill_figures_ed():
     results = dict()
-    for site in Site.objects.all():
+    for site in get_sites():
         print('Backfilling enrollment data for site "{}"'.format(site.domain))
         site_ed = backfill_enrollment_data_for_site(site)
         results[site.id] = site_ed

--- a/devsite/devsite/seed.py
+++ b/devsite/devsite/seed.py
@@ -43,7 +43,7 @@ from figures.helpers import (
 )
 from figures.pipeline import course_daily_metrics as pipeline_cdm
 from figures.pipeline import site_daily_metrics as pipeline_sdm
-from figures.sites import get_organizations_for_site
+from figures.sites import get_organizations_for_site, get_sites
 
 from devsite import cans
 from six.moves import range

--- a/devsite/devsite/test_settings.py
+++ b/devsite/devsite/test_settings.py
@@ -143,8 +143,10 @@ CELERYBEAT_SCHEDULE = {}
 FEATURES = {}
 
 # The LMS defines ``ENV_TOKENS`` to load settings declared in `lms.env.json`
-# We have an empty dict here to replicate behavior in the LMS
-ENV_TOKENS = {}
+# We have an (mostly) empty dict here to replicate behavior in the LMS
+ENV_TOKENS = {
+    'FIGURES': {},  # This variable is patched by the Figures' `lms_production.py` settings module.
+}
 
 # TODO: https://appsembler.atlassian.net/browse/RED-673
 # update_webpack_loader(WEBPACK_LOADER, ENV_TOKENS)

--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -48,6 +48,7 @@ home for functionality.
 from __future__ import absolute_import
 import calendar
 import datetime
+from importlib import import_module
 from django.conf import settings
 from django.utils.timezone import utc
 
@@ -79,6 +80,18 @@ def log_pipeline_errors_to_db():
     TODO: This is an environment/setting "getter". Should be moved to `figures.settings`
     """
     return bool(settings.FEATURES.get('FIGURES_LOG_PIPELINE_ERRORS_TO_DB', True))
+
+
+def import_from_path(path):
+    """
+    Import a function or class from a its string Python path.
+
+    :param path: string path in the format "module.submodule:variable".
+    :return object
+    """
+    module_path, variable_name = path.split(':', 1)
+    module = import_module(module_path)
+    return getattr(module, variable_name)
 
 
 def as_course_key(course_id):

--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -86,6 +86,11 @@ def import_from_path(path):
     """
     Import a function or class from a its string Python path.
 
+    Note: This help does _not_ attempt to handle exceptions well.
+      Instead it throws them as is. The rationale is that such exceptions are
+      only fixable at the deploy time and attempting to handle such errors
+      would risk hiding the errors and making it more difficult to fix.
+
     :param path: string path in the format "module.submodule:variable".
     :return object
     """

--- a/figures/management/commands/backfill_figures_metrics.py
+++ b/figures/management/commands/backfill_figures_metrics.py
@@ -63,12 +63,7 @@ class Command(BaseCommand):
         if options['site']:
             sites = [get_site(options['site'])]
         else:
-            # Would be great to be able to filter out dead sites
-            # Would be really great to be able to filter out dead sites
-            # Would be really Really great to be able to filter out dead sites
-            # Would be really Really REALLY great to be able to filter out dead sites
-
-            sites = Site.objects.all()
+            sites = get_sites()
         for site in sites:
             backfill_site(site, overwrite=options['overwrite'])
 

--- a/figures/management/commands/backfill_figures_metrics.py
+++ b/figures/management/commands/backfill_figures_metrics.py
@@ -13,6 +13,7 @@ from django.core.management.base import BaseCommand
 from figures.backfill import backfill_monthly_metrics_for_site
 from figures.sites import get_sites
 
+
 def get_site(identifier):
     """Quick-n-dirty function to let the caller choose the site id or domain
     Let the 'get' fail if record can't be found from the identifier

--- a/figures/management/commands/backfill_figures_metrics.py
+++ b/figures/management/commands/backfill_figures_metrics.py
@@ -11,7 +11,7 @@ from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 
 from figures.backfill import backfill_monthly_metrics_for_site
-
+from figures.sites import get_sites
 
 def get_site(identifier):
     """Quick-n-dirty function to let the caller choose the site id or domain

--- a/figures/management/commands/update_figures_enrollment_data.py
+++ b/figures/management/commands/update_figures_enrollment_data.py
@@ -44,11 +44,6 @@ class Command(BaseCommand):
         if options['site']:
             sites = [get_site(options['site'])]
         else:
-            # Would be great to be able to filter out dead sites
-            # Would be really great to be able to filter out dead sites
-            # Would be really Really great to be able to filter out dead sites
-            # Would be really Really REALLY great to be able to filter out dead sites
-
             sites = get_sites()
         for site in sites:
             print('Updating EnrollmentData for site "{}"'.format(site.domain))

--- a/figures/management/commands/update_figures_enrollment_data.py
+++ b/figures/management/commands/update_figures_enrollment_data.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
             # Would be really Really great to be able to filter out dead sites
             # Would be really Really REALLY great to be able to filter out dead sites
 
-            sites = Site.objects.all()
+            sites = get_sites()
         for site in sites:
             print('Updating EnrollmentData for site "{}"'.format(site.domain))
             if options['no_delay']:

--- a/figures/management/commands/update_figures_enrollment_data.py
+++ b/figures/management/commands/update_figures_enrollment_data.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 from figures.tasks import update_enrollment_data
+from figures.sites import get_sites
 
 
 def get_site(identifier):

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -23,7 +23,7 @@ from figures.helpers import as_course_key, as_date
 from figures.log import log_exec_time
 from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader
 from figures.pipeline.site_daily_metrics import SiteDailyMetricsLoader
-from figures.sites import site_course_ids
+from figures.sites import get_sites, site_course_ids
 from figures.pipeline.mau_pipeline import collect_course_mau
 from figures.pipeline.helpers import DateForCannotBeFutureError
 from figures.pipeline.site_monthly_metrics import fill_last_month as fill_last_smm_month

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -188,9 +188,7 @@ def populate_daily_metrics(date_for=None, force_update=False):
         date_for = today
 
     do_update_enrollment_data = False if date_for < today else True
-    # TODO: replace with helper function to abstract site filtering like a
-    # `figures.sites.active_sites`
-    sites = Site.objects.all()
+    sites = get_sites()
     sites_count = sites.count()
 
     # This is our task entry log message
@@ -356,7 +354,7 @@ def populate_all_mau():
     Initially, run it every day to observe monthly active user accumulation for
     the month and evaluate the results
     """
-    for site in Site.objects.all():
+    for site in get_sites():
         populate_mau_metrics_for_site(site_id=site.id, force_update=False)
 
 
@@ -378,8 +376,8 @@ def populate_monthly_metrics_for_site(site_id):
 @shared_task
 def run_figures_monthly_metrics():
     """
-    TODO: only run for active sites. Requires knowing which sites we can skip
+    Populate monthly metrics for all sites.
     """
     logger.info('Starting figures.tasks.run_figures_monthly_metrics...')
-    for site in Site.objects.all():
+    for site in get_sites():
         populate_monthly_metrics_for_site.delay(site_id=site.id)

--- a/figures/views.py
+++ b/figures/views.py
@@ -905,4 +905,4 @@ class SiteViewSet(StaffUserOnDefaultSiteAuthMixin, viewsets.ReadOnlyModelViewSet
     filter_class = SiteFilterSet
 
     def get_queryset(self):
-        return get_sites()
+        return figures.sites.get_sites()

--- a/figures/views.py
+++ b/figures/views.py
@@ -899,8 +899,10 @@ class SiteViewSet(StaffUserOnDefaultSiteAuthMixin, viewsets.ReadOnlyModelViewSet
     Access is restricted to global (Django instance) staff
     """
     model = Site
-    queryset = Site.objects.all()
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = SiteSerializer
     filter_backends = (DjangoFilterBackend, )
     filter_class = SiteFilterSet
+
+    def get_queryset(self):
+        return get_sites()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -21,6 +21,7 @@ from figures.helpers import (
     prev_day,
     previous_months_iterator,
     first_last_days_for_month,
+    import_from_path,
     )
 
 from tests.factories import COURSE_ID_STR_TEMPLATE
@@ -220,3 +221,30 @@ def test_first_last_days_for_month():
     assert last_day.year == year
     assert first_day.day == 1
     assert last_day.day == 29
+
+
+def test_import_from_path_working():
+    utc_tz_path = 'django.utils.timezone:utc'
+    imported_utc = import_from_path(utc_tz_path)
+    assert imported_utc is utc, 'Should import the utc variable correctly'
+
+
+def test_import_from_path_failing():
+    utc_tz_path = 'django.utils.timezone:non_existent_variable'
+    with pytest.raises(AttributeError):
+        # Should raise an AttributeError because the helper is using getattr()
+        import_from_path(utc_tz_path)
+
+
+def test_import_from_path_missing_module():
+    utc_tz_path = 'non_existent_module.submodule:some_variable'
+    with pytest.raises(ImportError):
+        # Should raise an ImportError because the module does not exist
+        import_from_path(utc_tz_path)
+
+
+def test_import_from_bad_syntax():
+    utc_tz_path = 'not a path'
+    with pytest.raises(ValueError):
+        # Malformed path
+        import_from_path(utc_tz_path)


### PR DESCRIPTION
RED-1721. This will help to make Figures use the `openedx.core.djangoapps.appsembler.sites.utils.get_active_sites` via configurations to make the pipeline run only for active sites.

This should help as both stopgap and long term solution for the increasing time of the pipeline.


### TODO

 - [x] Fix existing broken tests
 - [x] Add tests to cover both with/without backend
 - [ ] Document the setting variable?
