### PR TITLE
Reorganize the requirements files for Juniper tox tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
           - python: 2.7
             tox-env: py27-hawthorn_multisite
           - python: 3.5
-            tox-env: py35-juniper
-          - python: 3.8
-            tox-env: py38-juniper
+            tox-env: py35-juniper_community
+          - python: 3.5
+            tox-env: py35-juniper_multisite
           - python: 3.8
             tox-env: lint
           - python: 3.8

--- a/devsite/requirements/juniper_base.txt
+++ b/devsite/requirements/juniper_base.txt
@@ -24,7 +24,7 @@ pytz==2020.1
 ## Django package dependencies
 ##
 
-Django==2.2.15
+Django==2.2.16
 
 djangorestframework==3.9.4
 django-countries==5.5
@@ -34,6 +34,9 @@ django-filter==2.3.0
 django-environ==0.4.5
 
 jsonfield==2.1.1
+
+# For
+
 
 ##
 ## Documentation (Sphinx) dependencies
@@ -49,7 +52,6 @@ Sphinx==3.1.2
 edx-opaque-keys[django]==2.1.0
 #edx-drf-extensions==6.0.0
 
-edx-organizations==5.2.0
 
 ##
 ## Devsite 
@@ -75,3 +77,4 @@ pytest-cov==2.8.1
 tox==3.15.0
 freezegun==0.3.12
 edx-lint==1.4.1
+mock==3.0.5

--- a/devsite/requirements/juniper_community.txt
+++ b/devsite/requirements/juniper_community.txt
@@ -1,0 +1,5 @@
+# Requirements needed for Juniper community environment
+
+-r juniper_base.txt
+
+edx-organizations==5.2.0

--- a/devsite/requirements/juniper_multisite.txt
+++ b/devsite/requirements/juniper_multisite.txt
@@ -1,0 +1,6 @@
+# Requirements needed for Juniper multisite environment
+
+-r juniper_base.txt
+
+# Organization/site mapping requires Appsembler's fork
+git+https://github.com/appsembler/edx-organizations.git@5.2.0-appsembler13

--- a/devsite/requirements/py35_juniper.txt
+++ b/devsite/requirements/py35_juniper.txt
@@ -1,4 +1,0 @@
-
--r juniper_base.txt
-
-mock==3.0.5

--- a/devsite/requirements/py38_juniper.txt
+++ b/devsite/requirements/py38_juniper.txt
@@ -1,4 +1,0 @@
-
--r juniper_base.txt
-
-mock==4.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ envlist =
 	py27-ginkgo
 	py27-hawthorn
 	py27-hawthorn_multisite
-	py35-juniper
-	py38-juniper
+	py35-juniper_community
+	py35-juniper_multisite
 	lint
 	edx_lint_check
 
@@ -27,8 +27,8 @@ deps =
 	ginkgo: -r{toxinidir}/devsite/requirements/ginkgo.txt
 	hawthorn: -r{toxinidir}/devsite/requirements/hawthorn.txt
 	hawthorn_multisite: -r{toxinidir}/devsite/requirements/hawthorn_multisite.txt
-	py35_juniper: -r{toxinidir}/devsite/requirements/py35_juniper.txt
-	py38_juniper: -r{toxinidir}/devsite/requirements/py38_juniper.txt
+	juniper_community: -r{toxinidir}/devsite/requirements/juniper_community.txt
+	juniper_multisite: -r{toxinidir}/devsite/requirements/juniper_multisite.txt
 
 whitelist_externals =
 	git
@@ -40,15 +40,15 @@ setenv =
 	ginkgo: OPENEDX_RELEASE = GINKGO
 	hawthorn: OPENEDX_RELEASE = HAWTHORN
 	hawthorn_multisite: OPENEDX_RELEASE = HAWTHORN
-	py35_juniper: OPENEDX_RELEASE = JUNIPER
-	py38_juniper: OPENEDX_RELEASE = JUNIPER
+	juniper_community: OPENEDX_RELEASE = JUNIPER
+	juniper_multisite: OPENEDX_RELEASE = JUNIPER
 
 commands = 
 	ginkgo: pytest -c pytest-ginkgo.ini {posargs}
 	hawthorn: pytest -c pytest-hawthorn.ini {posargs}
 	hawthorn_multisite: pytest -c pytest-hawthorn.ini {posargs}
-	py35_juniper: pytest -c pytest-juniper.ini {posargs}
-	py38_juniper: pytest -c pytest-juniper.ini {posargs}
+	juniper_community: pytest -c pytest-juniper.ini {posargs}
+	juniper_multisite: pytest -c pytest-juniper.ini {posargs}
 
 [testenv:lint]
 basepython=python2


### PR DESCRIPTION
The purpose of this commit is to clean up the requirements files. This makes things a bit clearer. We now have a "Juniper community" mode and a "Juniper multisite" mode.

* We remove Py38 because Juniper needs to run in Py35
* The `juniper_community.txt` and `juniper_multisite.txt` requirements files read from `juniper_base.txt`. Each of the 'community' and 'multisite' have only the package differences, which at this point is the version/branch of `edx-organizations`

This PR is in preparation for another PR to improve asset building and testing devsite to support S3 based assets as well as local based assets