### PR TITLE
Juniper upgrade - Multi-asset build and static location flexibility

### DIFF
--- a/figures/settings/lms_production.py
+++ b/figures/settings/lms_production.py
@@ -6,19 +6,31 @@ import os
 from celery.schedules import crontab
 
 
+def get_build_label(release_line):
+    if release_line in ['ginkgo', 'hawthorn']:
+        return 'rb10'
+    else:
+        return 'rb16'
+
+
 def update_webpack_loader(webpack_loader_settings, figures_env_tokens):
     """
     Update the WEBPACK_LOADER in the settings.
     """
     # Specify the 'figures' package directory
-    figures_app_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+    from openedx.core.release import RELEASE_LINE  # noqa pylint: disable=import-error
+
+    build_label = get_build_label(RELEASE_LINE)
+    figures_app_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    figures_static_build_dir = 'static/figures/{label}'.format(label=build_label)
     # Define our webpack asset bundling constants
     # TODO: https://appsembler.atlassian.net/browse/RED-673
     webpack_stats_file = figures_env_tokens.get('WEBPACK_STATS_FILE', 'webpack-stats.json')
-    webpack_stats_full_path = os.path.abspath(os.path.join(figures_app_dir, webpack_stats_file))
+    webpack_stats_full_path = os.path.abspath(
+        os.path.join(figures_app_dir, figures_static_build_dir, webpack_stats_file))
     webpack_loader_settings.update(FIGURES_APP={
-        'BUNDLE_DIR_NAME': 'figures/',
+        'BUNDLE_DIR_NAME': 'figures/{label}/'.format(label=build_label),
         'STATS_FILE': webpack_stats_full_path,
     })
 

--- a/frontend/config/webpack.config.prod.js
+++ b/frontend/config/webpack.config.prod.js
@@ -56,7 +56,8 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
     { publicPath: Array(cssFilename.split('/').length).join('../') }
   : {};
 
-const figuresAppBuild = process.env.FIGURES_APP_BUILD ||  '../figures/static/figures';
+// Default to the REM_BASE=16
+const figuresAppBuild = process.env.FIGURES_APP_BUILD ||  '../figures/static/figures/rb16';
 const webpackStatsFile = figuresAppBuild + '/webpack-stats.json';
 
 // This is the production configuration.

--- a/frontend/config/webpack.config.prod.js
+++ b/frontend/config/webpack.config.prod.js
@@ -56,6 +56,9 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
     { publicPath: Array(cssFilename.split('/').length).join('../') }
   : {};
 
+const figuresAppBuild = process.env.FIGURES_APP_BUILD ||  '../figures/static/figures';
+const webpackStatsFile = figuresAppBuild + '/webpack-stats.json';
+
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
 // The development configuration is different and lives in a separate file.
@@ -76,7 +79,11 @@ module.exports = {
     filename: 'static/js/[name].[chunkhash:8].js',
     chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
     // We inferred the "public path" (such as / or /my-project) from homepage.
-    publicPath: publicPath,
+
+    // Remarked out 'pubilcPath' so that it would not be included in webpack-stats.json.
+    // This is done so that Django's 'staticfiles_storage.url' can resolve the asset URL.
+    // publicPath: publicPath,
+
     // Point sourcemap entries to original disk location (format as URL on Windows)
     devtoolModuleFilenameTemplate: info =>
       path
@@ -334,7 +341,8 @@ module.exports = {
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     // Make sure the webpack stats file can be read by Django Webpack Loader
     // when Figures is packaged for release on PyPI
-    new BundleTracker({filename: '../figures/webpack-stats.json'}),
+
+    new BundleTracker({filename: webpackStatsFile}),
     new ExtractTextPlugin({ filename: 'styles.css', allChunks: true }),
   ],
   // Some libraries import Node modules but don't use them in the browser.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
+    "multi-build": "node scripts/multi-build.js",
     "test": "node scripts/test.js --env=jsdom"
   },
   "jest": {

--- a/frontend/scripts/multi-build.js
+++ b/frontend/scripts/multi-build.js
@@ -1,0 +1,12 @@
+// This script builds multiple front end targets
+// We need this because the base font size changed from Hawthorn to Juniper
+
+// This for pre-Juniper
+process.env.REM_BASE = 10;
+process.env.FIGURES_APP_BUILD = '../figures/static/figures/rb10';
+require('./build.js');
+
+// This for Juniper (and maybe beyond)
+process.env.REM_BASE = 16;
+process.env.FIGURES_APP_BUILD = '../figures/static/figures/rb16';
+require('./build.js');

--- a/frontend/src/sass/base/_variables.scss
+++ b/frontend/src/sass/base/_variables.scss
@@ -1,6 +1,6 @@
 @import '~base/sass/base/functions';
 
-$rem-base-size: 10 !default;
+$rem-base-size: 16 !default;
 $base-font-size: calcRem(14) !default;
 $max-grid-width: calcRem(1180);
 $mobile-breakpoint: calcRem(420);


### PR DESCRIPTION
* New build script, 'multi-build' added to build multiple asset bundles
* Now two asset bundles are created
    * One for pre-Juniper with REM_BASE=10
    * Another for Juniper+ with REM_BASE=16
* 'publicPath' removed from webpack-stats.json file to allow for Webpack
to specify the static assets URL
* Which of the two asset bundle is determiend by the Open edX release
version

NOTE: This does not solve the "need to build assets for deployment" issue. So currently, we're still building an "asset bundle" deadend branch until we automate building assets into the dist bundle to push to PyPI