### PR TITLE
Handle old, slash-separated course ids and course-vX:... style

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -50,7 +50,10 @@ class App extends Component {
                   <Route exact path="/figures/courses" component={CoursesList} />
                   <Route exact path="/figures/learners-progress-overview" component={ProgressOverview} />
                   {(process.env.ENABLE_CSV_REPORTS === "enabled") && <Route exact path="/figures/csv-reports" component={CsvReports} />}
-                  <Route path="/figures/course/:courseId" render={({ match }) => <SingleCourseContent courseId={match.params.courseId} />}/>
+                  {/* course-v..-like course ids */}
+                  <Route path="/figures/course/(?!(\/))" render={({ match }) => <SingleCourseContent courseId={match.params[0]} />}/>
+                  {/* old slash-separated course id style */}
+                  <Route path="/figures/course/:courseOrg/:courseNum/:courseRun" render={({ match }) => <SingleCourseContent courseId={`${match.params.courseOrg}/${match.params.courseNum}/${match.params.courseRun}`} />}/>
                   <Route path="/figures/user/:userId" render={({ match }) => <SingleUserContent userId={match.params.userId} />}/>
                   <Route path="/figures/report/:reportId" render={({ match }) => <SingleReportContent reportId={match.params.reportId} />}/>
                   <Route component={DashboardContent} />


### PR DESCRIPTION
Allows Figures to run on sites with courses created in e.g., 2015

Split route path into two options:  if there are no forward-slashes we assume course id is like course-v1:xxx 
I didn't figure out how to get a nice named match param into my regex for that one but if you see how to, feel free.
Second one looks specifically for a course id style with two slash separations.

