### PR TITLE
build and publish figures on pypi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,44 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Build and upload Python package
+
+on:
+  release:
+    types: [published]
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Build frontend
+      run: |
+        cd frontend
+        npm install -g 'yarn@<2'
+        yarn
+        yarn build
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: 'Publish package (only for dev releases)'
+      # For now avoiding publishing production releases:
+      #   - The setuptools guide: https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+      if: ${{ startsWith(github.ref, 'refs/tags') && contains('.dev', github.ref) }}

--- a/frontend/src/views/MauDetailsContent.js
+++ b/frontend/src/views/MauDetailsContent.js
@@ -13,7 +13,7 @@ class MauDetailsContent extends Component {
   render() {
     let previousValue = undefined;
     const mausRender = this.props.mauHistory.map((period, index) => {
-      const difference = (previousValue || (previousValue == 0)) ? (period.value - previousValue) : 'N/A';
+      const difference = (previousValue || (previousValue === 0)) ? (period.value - previousValue) : 'N/A';
       previousValue = period.value;
       return (
         <li key={index} className={styles['content-row']}>

--- a/frontend/src/views/ProgressOverview.js
+++ b/frontend/src/views/ProgressOverview.js
@@ -72,7 +72,6 @@ class ProgressOverview extends Component {
         label: `${course.name} | ${course.number} | ${course.id}`,
         name: course.name,
         number: course.number,
-        id: course.id,
       }
       return (
         entry


### PR DESCRIPTION
This is an initial attempt to publish figures on pypi.

It'll probably not work so I've committed the publish step just to make sure the build can be done.

@johnbaldwin I hope this will be a pleasant surprise for you when you're back 🙂

This has been made from the Figures build and release steps in our confluence docs.

### Publish only `1.2.3.dev1` releases

This is still in testing and it's good not to mess up the Figures PyPI so this action will only publish `.dev` releases as described in the setuptools of Python: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries

One this is tested and working, we'll publish for all releases.

### Proposed workflow
This will enable a GitHub-based workflow which is completely different from the previous command line based one:

 - Update the version in the `setup.py` and make a PR
 - Merge the release bump PR
 - Publish a release on GitHub (done via the GUI)
 - The release is published automatically on PyPI

The workflow above is different from our [PyPI release Runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/41550165/New+PyPI+release).