### PR TITLE
Fix `contains()` flipped commands

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -41,4 +41,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-      if: ${{ startsWith(github.ref, 'refs/tags') && contains('.dev', github.ref) }}
+      if: ${{ startsWith(github.ref, 'refs/tags') && contains(github.ref, '.dev') }}


### PR DESCRIPTION
I had the parameters flipped!

https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contains


> #### contains
> 
> `contains( search, item )`
> 
> Returns `true` if `search` contains `item`. If `search` is an array, this function returns `true` if the `item` is an element in the array. If `search` is a string, this function returns `true` if the `item` is a substring of `search`. This function is not case sensitive. Casts values to a string.