### PR TITLE
release both release and pre-releases tags to PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,11 +34,9 @@ jobs:
         pip install build
     - name: Build package
       run: python -m build
-    - name: 'Publish package (only for dev releases)'
-      # For now avoiding publishing production releases:
-      #   - The setuptools guide: https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
+    - name: 'Publish package'
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-      if: ${{ startsWith(github.ref, 'refs/tags') && contains(github.ref, '.dev') }}
+      if: ${{ startsWith(github.ref, 'refs/tags') }}


### PR DESCRIPTION
This is a change would allow releasing `0.4.1` into PyPI instead of just pre-releases.