### PR TITLE
Don't use get_site_ids in backfill_daily_metrics...

### DIFF
--- a/figures/management/commands/backfill_figures_daily_metrics.py
+++ b/figures/management/commands/backfill_figures_daily_metrics.py
@@ -57,7 +57,7 @@ class Command(BaseBackfillCommand):
             print('BEGIN: Backfill Figures daily metrics metrics for: {}'.format(dt))
 
             kwargs = dict(
-                site_id=self.get_site_ids(options['site'])[0],
+                site_id=options['site'],
                 date_for=str(dt),
                 force_update=options['overwrite']
             )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -92,12 +92,10 @@ class TestBackfillDailyMetrics(object):
             assert mock_populate.call_count == exp_days
 
     def test_backfill_daily_for_site(self):
-        """Test that proper site id gets passed to task func.  Doesn't exercise get_side_ids."""
-        with mock.patch('figures.management.base.BaseBackfillCommand.get_site_ids') as mock_get_site_ids:
-            mock_get_site_ids.return_value = [1,]
-            with mock.patch(self.PLAIN_PATH) as mock_populate:
-                call_command('backfill_figures_daily_metrics', no_delay=True)
-                assert mock_populate.called_with(site_id=1)
+        """Test that proper site id gets passed to task func."""
+        with mock.patch(self.PLAIN_PATH) as mock_populate:
+            call_command('backfill_figures_daily_metrics', no_delay=True)
+            assert mock_populate.called_with(site_id=1)
 
 
 class TestPopulateFiguresMetricsCommand(object):


### PR DESCRIPTION
populate_daily_metrics will do that.  Just pass site=None if
none passed and task will run for all Sites


## Change description

> This only affects multisite deployments when using backfill_figutes_daily_metrics, but is a bug introduced and released in 0.4.dev13.  We'll need to cut a new one.  

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
