### PR TITLE
Allow site arg by domain name again for backfill_figures_daily_metrics

### DIFF
--- a/figures/management/commands/backfill_figures_daily_metrics.py
+++ b/figures/management/commands/backfill_figures_daily_metrics.py
@@ -51,13 +51,16 @@ class Command(BaseBackfillCommand):
             date_start, date_end
         ))
 
+        # don't pass multiple site ids to tasks
+        site_id = None if not options['site'] else self.get_site_ids(options['site'])
+
         # populate daily metrics one day at a time for date range
         for dt in rrule(DAILY, dtstart=date_start, until=date_end):
 
             print('BEGIN: Backfill Figures daily metrics metrics for: {}'.format(dt))
 
             kwargs = dict(
-                site_id=options['site'],
+                site_id=site_id,
                 date_for=str(dt),
                 force_update=options['overwrite']
             )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -78,7 +78,10 @@ class TestBackfillDailyMetrics(object):
         end_dt = parser.parse(end)
         exp_days = abs((end_dt - start_dt).days) + 1
         with mock.patch(self.PLAIN_PATH) as mock_populate:
-            call_command('backfill_figures_daily_metrics', date_start=start, date_end=end, no_delay=True)
+            call_command(
+                'backfill_figures_daily_metrics', 
+                date_start=start, date_end=end, no_delay=True
+            )
             assert mock_populate.call_count == exp_days
 
     def test_backfill_daily_same_day(self):
@@ -88,14 +91,31 @@ class TestBackfillDailyMetrics(object):
         end = '2021-06-08'
         exp_days = 1
         with mock.patch(self.PLAIN_PATH) as mock_populate:
-            call_command('backfill_figures_daily_metrics', date_start=start, date_end=end, no_delay=True)
+            call_command(
+                'backfill_figures_daily_metrics', 
+                date_start=start, date_end=end, no_delay=True
+            )
             assert mock_populate.call_count == exp_days
 
-    def test_backfill_daily_for_site(self):
-        """Test that proper site id gets passed to task func."""
+    def test_backfill_daily_with_site_id(self):
+        """Test that proper site id gets passed to task func when passing integer."""
+        with mock.patch(self.PLAIN_PATH) as mock_populate:
+            call_command('backfill_figures_daily_metrics', site=1, no_delay=True)
+            assert mock_populate.called_with(site_id=1)
+
+    def test_backfill_daily_with_site_domain(self):
+        """Test that proper site id gets passed to task func when passing integer."""
+        SiteFactory.reset_sequence(0)
+        site2 = SiteFactory()  # site-0.example.com
+        with mock.patch(self.PLAIN_PATH) as mock_populate:
+            call_command('backfill_figures_daily_metrics', site="site-0.example.com", no_delay=True)
+            assert mock_populate.called_with(site_id=2)
+
+    def test_backfill_daily_without_site_id(self):
+        """Test that proper site id gets passed to task func when passing integer."""
         with mock.patch(self.PLAIN_PATH) as mock_populate:
             call_command('backfill_figures_daily_metrics', no_delay=True)
-            assert mock_populate.called_with(site_id=1)
+            assert mock_populate.called_with(site_id=None)
 
 
 class TestPopulateFiguresMetricsCommand(object):


### PR DESCRIPTION
My last PR wasn't quite right, since it did away with the option to pass a domain name instead of Site id—way more convenient. This brings back that ability for backfill_figures_daily_metrics