### PR TITLE
Handle edge case w/ days to complete, where cert exists w/o enrollment

### DIFF
--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -163,7 +163,16 @@ def get_days_to_complete(course_id, date_for):
                      course_id=course_id,
                      user_id=cert.user.id,
                      ))
-        days.append((cert.created_date - ce[0].created).days)
+        try:
+            days.append((cert.created_date - ce[0].created).days)
+        except IndexError:
+            # sometimes a course enrollment is deleted after the cert is generated.  why, who knows?
+            # in which case just leave out that data
+            errors.append(
+                dict(msg='No CourseEnrollment matching user course certificate',
+                     course_id=course_id,
+                     user_id=cert.user.id,
+                     ))
     return dict(days=days, errors=errors)
 
 


### PR DESCRIPTION
## Change description

> Found cases where a GeneratedCertificate existed for a user/course but the CourseEnrollment for user/course no longer existed.  Odd edge case breaking calculation of days to complete.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
