### PR TITLE
Ginkgo devsite: edx-drf-extensions 0.5.1 for edx-organizations compat

### DIFF
--- a/devsite/requirements/ginkgo.txt
+++ b/devsite/requirements/ginkgo.txt
@@ -52,8 +52,9 @@ recommonmark==0.4.0
 ##
 
 edx-opaque-keys==0.4
-# edx-organizations 0.4.4 requires edx-drf-extensions<1.0.0,>=0.5.1, but you'll have edx-drf-extensions 1.2.2 which is incompatible.
-edx-drf-extensions==1.2.2
+# edx-organizations 0.4.4 requires edx-drf-extensions<1.0.0,>=0.5.1, but 
+# Ginkgo edx-platform open release specifies edx-drf-extensions 1.2.2 which is incompatible.  We will use what's compatible with edx-organizations.
+edx-drf-extensions==0.5.1
 edx-organizations==0.4.4
 
 


### PR DESCRIPTION
## Change description

Ginkgo devsite was using edx-drf-extensions 1.2.2 as used by edx-platform Ginkgo open-release, which is actually incompatible with the edx-drf-extensions required by edx-organizations 0.4.4.  That must have broken install of Ginkgo.
For our use, go with the version required by 0.4.4.  The only difference to edx-drf-extensions 1.2.2 is treatment of JWT tokens, which doesn't matter for Figures anyhow.

Allows Ginkgo tests to run via `tox -e gingko`

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
