### PR TITLE
Remove unneeded XFail on test_backfill

### DIFF
--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -72,7 +72,6 @@ def backfill_test_data(db):
     )
 
 
-@pytest.mark.xfail  # See: https://github.com/appsembler/figures/issues/354
 def test_backfill_monthly_metrics_for_site(backfill_test_data):
     """Simple coverage and data validation check for the function under test
 


### PR DESCRIPTION
Related https://github.com/appsembler/figures/issues/354 was already fixed by https://github.com/appsembler/figures/pull/358 so removing related XFail in tests