### PR TITLE
fix flaky `test_backfill_monthly_metrics_for_site` by freezing time

### DIFF
--- a/devsite/requirements/test.txt
+++ b/devsite/requirements/test.txt
@@ -1,0 +1,2 @@
+# Shared testing requirements
+pytest-freezegun==0.4.2

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -72,6 +72,7 @@ def backfill_test_data(db):
     )
 
 
+@pytest.mark.freeze_time('2019-09-01 12:00:00')
 def test_backfill_monthly_metrics_for_site(backfill_test_data):
     """Simple coverage and data validation check for the function under test
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
 	hawthorn_multisite: -r{toxinidir}/devsite/requirements/hawthorn_multisite.txt
 	juniper_community: -r{toxinidir}/devsite/requirements/juniper_community.txt
 	juniper_multisite: -r{toxinidir}/devsite/requirements/juniper_multisite.txt
+	-r{toxinidir}/devsite/requirements/test.txt
 
 whitelist_externals =
 	git


### PR DESCRIPTION
 `test_backfill_monthly_metrics_for_site` seems to fail sometimes depending on the time it's being run. using [pytest-freezegun](https://pypi.org/project/pytest-freezegun/) to freeze the time and make sure it returns consistent results.

### Old failure on Jun 30, 2021

![image](https://user-images.githubusercontent.com/645156/124899442-caa2b680-dfe8-11eb-8303-a280fd214f43.png)