### PR TITLE
Option to use raw SQL to improve performance of site monthly metrics with large #s of StudentModules

### DIFF
--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -19,7 +19,7 @@ from figures.pipeline.site_monthly_metrics import fill_month
 from figures.models import EnrollmentData
 
 
-def backfill_monthly_metrics_for_site(site, overwrite=False):
+def backfill_monthly_metrics_for_site(site, overwrite=False, use_raw_sql=False):
     """Backfill specified months' historical site metrics for the specified site
     """
     site_sm = get_student_modules_for_site(site)
@@ -38,7 +38,8 @@ def backfill_monthly_metrics_for_site(site, overwrite=False):
         obj, created = fill_month(site=site,
                                   month_for=dt,
                                   student_modules=site_sm,
-                                  overwrite=overwrite)
+                                  overwrite=overwrite,
+                                  use_raw=use_raw_sql)
         backfilled.append(dict(obj=obj, created=created, dt=dt))
 
     return backfilled

--- a/figures/management/commands/backfill_figures_monthly_metrics.py
+++ b/figures/management/commands/backfill_figures_monthly_metrics.py
@@ -13,7 +13,7 @@ from figures.backfill import backfill_monthly_metrics_for_site
 from figures.management.base import BaseBackfillCommand
 
 
-def backfill_site(site, overwrite):
+def backfill_site(site, overwrite, use_raw_sql):
 
     print('Backfilling monthly metrics for site id={} domain={}'.format(
         site.id,
@@ -42,7 +42,8 @@ class Command(BaseBackfillCommand):
         '''
         parser.add_argument(
             '--use_raw_sql',
-            help='Use raw SQL for query performance with large number of StudentModules, where supported.',
+            help=('Use raw SQL for query performance with large number of StudentModules, '
+                  'where supported.'),
             default=False,
             action="store_true"
         )
@@ -53,6 +54,6 @@ class Command(BaseBackfillCommand):
 
         for site_id in self.get_site_ids(options['site']):
             site = Site.objects.get(id=site_id)
-            backfill_site(site, overwrite=options['overwrite'])
+            backfill_site(site, overwrite=options['overwrite'], use_raw_sql=options['use_raw_sql'])
 
         print('END: Backfill Figures Metrics')

--- a/figures/management/commands/backfill_figures_monthly_metrics.py
+++ b/figures/management/commands/backfill_figures_monthly_metrics.py
@@ -19,7 +19,8 @@ def backfill_site(site, overwrite):
         site.id,
         site.domain))
     backfilled = backfill_monthly_metrics_for_site(site=site,
-                                                   overwrite=overwrite)
+                                                   overwrite=overwrite,
+                                                   use_raw_sql=use_raw_sql)
     if backfilled:
         for rec in backfilled:
             obj = rec['obj']
@@ -35,6 +36,17 @@ class Command(BaseBackfillCommand):
     """Backfill Figures monthly metrics models.
     """
     help = dedent(__doc__).strip()
+
+    def add_arguments(self, parser):
+        '''
+        '''
+        parser.add_argument(
+            '--use_raw_sql',
+            help='Use raw SQL for query performance with large number of StudentModules, where supported.',
+            default=False,
+            action="store_true"
+        )
+        super(Command, self).add_arguments(parser)
 
     def handle(self, *args, **options):
         print('BEGIN: Backfill Figures Monthly Metrics')

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -73,7 +73,8 @@ def backfill_test_data(db):
 
 
 @pytest.mark.freeze_time('2019-09-01 12:00:00')
-def test_backfill_monthly_metrics_for_site(backfill_test_data):
+@pytest.mark.parametrize('use_raw_sql', (True, False))
+def test_backfill_monthly_metrics_for_site(backfill_test_data, use_raw_sql):
     """Simple coverage and data validation check for the function under test
 
     Example backfilled results
@@ -101,7 +102,7 @@ def test_backfill_monthly_metrics_for_site(backfill_test_data):
     site = backfill_test_data['site']
     count_check = backfill_test_data['count_check']
     assert not SiteMonthlyMetrics.objects.count()
-    backfilled = backfill_monthly_metrics_for_site(site=site, overwrite=True)
+    backfilled = backfill_monthly_metrics_for_site(site=site, overwrite=True, use_raw_sql=use_raw_sql)
     assert len(backfilled) == backfill_test_data['months_back']
     assert len(backfilled) == SiteMonthlyMetrics.objects.count()
     assert len(backfilled) == len(count_check)

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -5,11 +5,14 @@ from datetime import datetime
 import pytest
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import rrule, MONTHLY
+from six.moves import range
+from six.moves import zip
+
+from django.db import connection
 from django.utils.timezone import utc
 
 from figures.backfill import backfill_monthly_metrics_for_site
 from figures.models import SiteMonthlyMetrics
-
 from tests.factories import (
     CourseOverviewFactory,
     OrganizationFactory,
@@ -17,8 +20,6 @@ from tests.factories import (
     StudentModuleFactory,
     SiteFactory)
 from tests.helpers import organizations_support_sites
-from six.moves import range
-from six.moves import zip
 
 
 if organizations_support_sites():
@@ -72,9 +73,23 @@ def backfill_test_data(db):
     )
 
 
+def patched__get_fill_month_raw_sql_for_month(site_ids, month_for):
+    """Get SQL statement for fill_month use_raw_sql option... that works with SQLite in test.
+    """
+    if (connection.vendor == 'sqlite'):
+        month = str(month_for.month).zfill(2)
+        year = month_for.year
+        return """\
+        SELECT COUNT(DISTINCT student_id) from courseware_studentmodule
+        where id in {}
+        and strftime('%m', datetime(modified)) = '{}'
+        and strftime('%Y', datetime(modified)) = '{}'
+        """.format(site_ids, month, year)
+
+
 @pytest.mark.freeze_time('2019-09-01 12:00:00')
 @pytest.mark.parametrize('use_raw_sql', (True, False))
-def test_backfill_monthly_metrics_for_site(backfill_test_data, use_raw_sql):
+def test_backfill_monthly_metrics_for_site(monkeypatch, backfill_test_data, use_raw_sql):
     """Simple coverage and data validation check for the function under test
 
     Example backfilled results
@@ -99,6 +114,12 @@ def test_backfill_monthly_metrics_for_site(backfill_test_data, use_raw_sql):
     and make sure that `modified` dates are used in the production code and not
     `created` dates
     """
+    # monkeypatch the function which produces the raw sql w/one will work in test
+    monkeypatch.setattr(
+        "figures.pipeline.site_monthly_metrics._get_fill_month_raw_sql_for_month",
+        patched__get_fill_month_raw_sql_for_month
+    )
+
     site = backfill_test_data['site']
     count_check = backfill_test_data['count_check']
     assert not SiteMonthlyMetrics.objects.count()


### PR DESCRIPTION
## Change description

Tries to resolve performance issues running backfill_figures_monthly_metrics or even just running the site monthly metrics each month by schedule, in cases where there is a large number of students and StudentModules.  I was not able to complete a month on a site with 95k students and ~7 million StudentModule records without pegging system memory and making the whole site unresponsive.   

Using a raw SQL query provides performance benefits over using Python/Django... The main bottleneck with Django is the calculation of distinct() student_ids on the QuerySets.  Raw SQL DISTINCT() function is significantly more performant.

This PR provide a use_raw parameter to pipelines.site_monthly_metrics.fill_month and "upstream" functions and management commands.  

Includes tests, though the actual SQL statement has to be changed to accommodate the differences in sqllite.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
