### PR TITLE
fix some link colors

### DIFF
--- a/frontend/src/components/header-views/header-content-maus/_header-content-maus.scss
+++ b/frontend/src/components/header-views/header-content-maus/_header-content-maus.scss
@@ -66,14 +66,14 @@
     padding: calcRem(5) calcRem(10);
     border: calcRem(2) solid pick-visible-color($primary-color, #fff, $base-text-color);
     border-radius: calcRem(50);
-    color: pick-visible-color($primary-color, #fff, $base-text-color);
+    color: pick-visible-color($primary-color, #fff, $base-text-color) !important;
     text-decoration: none;
     cursor: pointer;
     transition: all 0.2s ease-in-out;
 
     &:hover {
       background-color: pick-visible-color($primary-color, #fff, $base-text-color);
-      color: pick-visible-color(pick-visible-color($primary-color, #fff, $base-text-color), #fff, $primary-color);
+      color: pick-visible-color(pick-visible-color($primary-color, #fff, $base-text-color), #fff, $primary-color) !important;
     }
   }
 

--- a/frontend/src/components/layout/_header-nav.scss
+++ b/frontend/src/components/layout/_header-nav.scss
@@ -11,7 +11,7 @@ a.header-nav__link, a.header-nav__link:not(.btn) {
   margin-right: calcRem(30);
   font-size: $base-font-size;
   font-weight: 600;
-  color: pick-visible-color($primary-color, #fff, $base-text-color);
+  color: pick-visible-color($primary-color, #fff, $base-text-color) !important;
   text-decoration: none;
   position: relative;
 

--- a/frontend/src/views/_dashboard-content.scss
+++ b/frontend/src/views/_dashboard-content.scss
@@ -26,7 +26,7 @@
     padding: calcRem(15) calcRem(25);
     margin: calcRem(30) auto calcRem(50);
     font-weight: bold;
-    color: $primary-color;
+    color: $primary-color !important;
     border: calcRem(2) solid $primary-color;
     background: transparent;
     cursor: pointer;
@@ -35,7 +35,7 @@
     text-decoration: none;
 
     &:hover {
-      color: #fff;
+      color: #fff !important;
       background: $primary-color;
     }
   }


### PR DESCRIPTION
Fix for the issue where super specific link stylings in Open edX css override link colors. Dirty (khm khm`!important`) but it works.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
