### PR TITLE
Fix CourseEnrollment display 'leakage' betwen Sites

### DIFF
--- a/figures/sites.py
+++ b/figures/sites.py
@@ -210,7 +210,9 @@ def get_users_for_site(site):
 def get_course_enrollments_for_site(site):
     if is_multisite():
         course_enrollments = CourseEnrollment.objects.filter(
-            user__organizations__sites__in=[site])
+            user__organizations__sites__in=[site],
+            course_id__in=get_course_keys_for_site(site)
+        )
     else:
         course_enrollments = CourseEnrollment.objects.all()
     return course_enrollments

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -288,7 +288,9 @@ def site_certificates(site):
     """
     if is_multisite():
         return GeneratedCertificate.objects.filter(
-            user__organizations__sites__in=[site])
+            user__organizations__sites__in=[site],
+            course_id__in=get_course_keys_for_site(site)
+        )
     else:
         return GeneratedCertificate.objects.all()
 

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -208,8 +208,6 @@ class TestHandlersForMultisiteMode(object):
         assert set([ce.id for ce in course_enrollments]) == set(
                    [ce.id for ce in expected_ce])
 
-    # TODO: remove xfail after fixing filtering get_course_enrollments_for_site by Site
-    @pytest.mark.xfail  # for now, since this is just for TDD at this point.  
     def test_get_course_enrollments_for_site_exclude_same_user_different_site(self):
         """
         Test that CEs are not returned from course from another Site, in cases where a user has


### PR DESCRIPTION
## Change description

Limit display of CourseEnrollments to requested Site in cases where users have enrollments for courses in more than one Site

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

fix https://github.com/appsembler/figures/issues/392

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
