### PR TITLE
add bandit security tests

### DIFF
--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,2 @@
+exclude_dirs:
+  - '/tests/'

--- a/tox.ini
+++ b/tox.ini
@@ -74,3 +74,9 @@ deps =
 	-r{toxinidir}/devsite/requirements/hawthorn.txt
 commands =
 	edx_lint write pylintrc
+
+[testenv:bandit]
+deps =
+    bandit==1.7.1
+commands =
+    bandit -c bandit.yaml -r figures


### PR DESCRIPTION
Bandit finds a couple issues (see `tox -e bandit` for the report). Those should be addressed separately. Once everything is passing, we can add it to the Github Actions workflow.
