### PR TITLE
Include Red Team in default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,10 @@
 # see: https://appsembler.atlassian.net/wiki/spaces/ED/pages/2227503161/CODEOWNERS
 
+
+# Code owner
 * @johnbaldwin
+
+
+# Default reviewers
+* @johnbaldwin @omarithawi @melvinsoft @shadinaif @estherjsuh
+


### PR DESCRIPTION
This is useful to review Figures changes in for Tahoe SaaS production needs.