### PR TITLE
Fixes serializer tests failing locally in Ginkgo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 
 
 # Default reviewers
-* @johnbaldwin @omarithawi @melvinsoft @shadinaif @estherjsuh
+* @johnbaldwin @omarithawi @melvinsoft @shadinaif @estherjsuh @bryanlandia
 


### PR DESCRIPTION
* The version 2.4.2 `dateutil.parser.parse` method returns a `datetime`
object in local time, causing the tests to fail when compared against
datetime in UTC
* This commit addresses the issue by replacing the timezone with UTC
* This commit includes a helper function, `as_datetime_utc` in tests/test_serializers.py
* Read the docstring for this helper function
