### PR TITLE
Fixes serializer tests failing locally in Ginkgo

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,8 +3,11 @@
 
 from __future__ import absolute_import
 import os
+from dateutil.parser import parse as dateutil_parse
 from dateutil.rrule import rrule, DAILY
 from packaging import version
+
+from django.utils.timezone import utc
 
 from organizations.models import Organization
 
@@ -65,3 +68,22 @@ def django_filters_pre_v2():
     """
     import django_filters
     return version.parse(django_filters.__version__) < version.parse('2.0.0')
+
+
+def as_datetime_utc(datetime_string):
+    """Returns `datetime` instance with UTC timezone
+
+    This helpler function centralizes converting  "datetime as a string" to a
+    datetime object in UTC.
+
+    We use dateutil.parser.parse because it is convenient. However, these tests
+    need to support mulitple versions of Open edX and with that, multiple versions
+    of the dateutil package. While the dateutil package does handle timezone
+    assignment, this approach is more portable.
+
+    We may want to iterate on this to create a 'datetime_matches' function.
+    However, then we have to consider type checking for the parameters, or
+    enforce one type as string and the other as datetime, or do conversions.
+    Basically, we might be making testing more complicated
+    """
+    return dateutil_parse(datetime_string).replace(tzinfo=utc)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -7,7 +7,7 @@ import datetime
 from dateutil.parser import parse as dateutil_parse
 from decimal import Decimal
 import pytest
-import pytz
+# import pytz
 
 from django.contrib.sites.models import Site
 from django.db import models
@@ -55,27 +55,8 @@ from tests.factories import (
     SiteFactory,
     )
 
-from tests.helpers import platform_release
+from tests.helpers import as_datetime_utc, platform_release
 import six
-
-
-def as_datetime_utc(datetime_string):
-    """Returns `datetime` instance with UTC timezone
-
-    This helpler function centralizes converting  "datetime as a string" to a
-    datetime object in UTC.
-
-    We use dateutil.parser.parse because it is convenient. However, these tests
-    need to support mulitple versions of Open edX and with that, multiple versions
-    of the dateutil package. While the dateutil package does handle timezone
-    assignment, this approach is more portable.
-
-    We may want to iterate on this to create a 'datetime_matches' function.
-    However, then we have to consider type checking for the parameters, or
-    enforce one type as string and the other as datetime, or do conversions.
-    Basically, we might be making testing more complicated
-    """
-    return dateutil_parse(datetime_string).replace(tzinfo=utc)
 
 
 class TestSerializableCountryField(object):
@@ -428,7 +409,7 @@ class TestGeneralUserDataSerializer(object):
 
     @pytest.fixture(autouse=True)
     def setup(self, db):
-        self.a_datetime = datetime.datetime(2018, 2, 2, tzinfo=pytz.UTC)
+        self.a_datetime = datetime.datetime(2018, 2, 2, tzinfo=utc)
         self.user_attributes = {
             'username': 'alpha_one',
             'email': 'alpha_one@example.com',


### PR DESCRIPTION
* The version 2.4.2 `dateutil.parser.parse` method returns a `datetime`
object in local time, causing the tests to fail when compared against
datetime in UTC
* This commit addresses the issue by replacing the timezone with UTC
* This commit includes a helper function, `as_datetime_utc` in tests/test_serializers.py
* Read the docstring for this helper function
