### PR TITLE
Auto upgrade to latest pip in tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,8 @@ skip_missing_interpreters=true
 [pytest]
 
 [testenv]
+download = true
+
 deps =
 	ginkgo: -r{toxinidir}/devsite/requirements/ginkgo.txt
 	hawthorn: -r{toxinidir}/devsite/requirements/hawthorn.txt


### PR DESCRIPTION
## Change description

**When running tox locally:**
In Ubuntu 20.04, tox will create Python2.7 virtual environments with `pip==20.0.2` instead of `20.3.4`. Installing requirements fails because of that. This small update is to tell tox to upgrade pip to latest before installing packages

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
