### PR TITLE
Pipeline improvement prerequisites

### DIFF
--- a/devsite/.env.example
+++ b/devsite/.env.example
@@ -15,8 +15,8 @@ DATABASE_URL=mysql://figures_user:drowssap-ekaf@127.0.0.1:3306/figures-db
 # Set which expected Open edX release mocks for devsite to use.
 # Valid options are: "GINKGO", "HAWTHORN", "JUNIPER"
 #
-# If not specified here, then "HAWTHORN" is used
-OPENEDX_RELEASE=JUNIPER
+# If not specified here, then "JUNIPER" is used
+# OPENEDX_RELEASE=JUNIPER
 
 # Enable/disable Figures multisite mode in devsite
 # This also requires

--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -14,6 +14,7 @@ import environ
 from figures.settings.lms_production import (
     update_webpack_loader,
     update_celerybeat_schedule,
+    update_celery_routes,
 )
 
 DEVSITE_BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -22,7 +23,7 @@ PROJECT_ROOT_DIR = os.path.dirname(DEVSITE_BASE_DIR)
 env = environ.Env(
     DEBUG=(bool, True),
     ALLOWED_HOSTS=(list, []),
-    OPENEDX_RELEASE=(str, 'HAWTHORN'),
+    OPENEDX_RELEASE=(str, 'JUNIPER'),
     FIGURES_IS_MULTISITE=(bool, False),
     ENABLE_DEVSITE_CELERY=(bool, True),
     ENABLE_OPENAPI_DOCS=(bool, False),
@@ -240,8 +241,16 @@ FEATURES = {
 # We have an empty dict here to replicate behavior in the LMS
 ENV_TOKENS = {}
 
+PRJ_SETTINGS = {
+    'CELERY_ROUTES': "app.celery.routes"
+}
+
+FIGURES_PIPELINE_TASKS_ROUTING_KEY = ""
+
 update_webpack_loader(WEBPACK_LOADER, ENV_TOKENS)
-update_celerybeat_schedule(CELERYBEAT_SCHEDULE, ENV_TOKENS)
+update_celerybeat_schedule(CELERYBEAT_SCHEDULE, ENV_TOKENS, FIGURES_PIPELINE_TASKS_ROUTING_KEY)
+update_celery_routes(PRJ_SETTINGS, ENV_TOKENS, FIGURES_PIPELINE_TASKS_ROUTING_KEY)
+
 
 # Used by Django Debug Toolbar
 INTERNAL_IPS = [

--- a/devsite/devsite/test_settings.py
+++ b/devsite/devsite/test_settings.py
@@ -28,7 +28,7 @@ def root(*args):
 
 
 env = environ.Env(
-    OPENEDX_RELEASE=(str, 'HAWTHORN'),
+    OPENEDX_RELEASE=(str, 'JUNIPER'),
 )
 
 environ.Env.read_env(join(dirname(dirname(__file__)), '.env'))

--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -1,6 +1,7 @@
 """Helper functions to make data handling and conversions easier
 
 # Figures 0.3.13 - Defining scope of this module
+# Figures 0.4.x - Yep, this module is still handy and the scope hasn't exploded
 
 The purpose of this module is to provide conveniece methods around commonly
 executed statements. These convenience methods should serve as shorthand for
@@ -34,6 +35,8 @@ repeat yourself) the code and make the code more readable
 
 ## What does not belong here?
 
+* Most importantly, if you have to import from another figures module, it does
+  not belong here!
 * "Feature" functionality does not belong here
 * Long functions do not belong here
 * Code that communicates outside of Figures does not belong here. No database,
@@ -42,7 +45,10 @@ repeat yourself) the code and make the code more readable
 This is not an exhaustive list. We'll grow it as needed.
 
 An important point is that we should not expect this module to be a permanent
-home for functionality.
+home for the functionality included. As we evolve Figures, we may find functions
+here that have a stronger context with another module. For example, we've got
+a decent set of date oriented functions that are candidatdes for a datetime and
+date handling module.
 """
 
 from __future__ import absolute_import
@@ -186,6 +192,15 @@ def next_day(val):
 
 def prev_day(val):
     return days_from(val, -1)
+
+
+def utc_yesterday():
+    """Get "yesterday" form the utc datetime
+
+    We primarily use this for the daily metrics collection. However, it proves
+    handy as a convenience function for exploring data in the Django shell
+    """
+    return prev_day(datetime.datetime.utcnow().date())
 
 
 def days_in_month(month_for):

--- a/figures/migrations/0016_add_collect_elapsed_to_ed_and_lcgm.py
+++ b/figures/migrations/0016_add_collect_elapsed_to_ed_and_lcgm.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('figures', '0015_add_enrollment_data_model'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enrollmentdata',
+            name='collect_elapsed',
+            field=models.FloatField(null=True),
+        ),
+        migrations.AddField(
+            model_name='learnercoursegrademetrics',
+            name='collect_elapsed',
+            field=models.FloatField(null=True),
+        ),
+    ]

--- a/figures/models.py
+++ b/figures/models.py
@@ -5,7 +5,7 @@ TODO: Create a base "SiteModel" or a "SiteModelMixin"
 
 from __future__ import absolute_import
 from datetime import date
-import timeit
+from time import time
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -283,7 +283,7 @@ class EnrollmentDataManager(models.Manager):
 
         if not ed_recs or ed_recs[0].date_for < date_for or force_update:
             # We do the update
-            start_time = timeit.default_timer()
+            start_time = time()
             # get the progress data
             ep = EnrollmentProgress(user=course_enrollment.user,
                                     course_id=str(course_enrollment.course_id))
@@ -298,7 +298,7 @@ class EnrollmentDataManager(models.Manager):
                 is_enrolled=course_enrollment.is_active,
                 date_enrolled=course_enrollment.created,
             )
-            elapsed = timeit.default_timer() - start_time
+            elapsed = time() - start_time
             defaults['collect_elapsed'] = elapsed
 
             ed_rec, created = self.update_or_create(

--- a/figures/models.py
+++ b/figures/models.py
@@ -5,6 +5,7 @@ TODO: Create a base "SiteModel" or a "SiteModelMixin"
 
 from __future__ import absolute_import
 from datetime import date
+import timeit
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -17,7 +18,7 @@ from jsonfield import JSONField
 from model_utils.models import TimeStampedModel
 
 from figures.compat import CourseEnrollment
-from figures.helpers import as_course_key
+from figures.helpers import as_course_key, utc_yesterday
 from figures.progress import EnrollmentProgress
 
 
@@ -203,7 +204,7 @@ class EnrollmentDataManager(models.Manager):
     EnrollmentData instances.
 
     """
-    def set_enrollment_data(self, site, user, course_id, course_enrollment=False):
+    def set_enrollment_data(self, site, user, course_id, course_enrollment=None):
         """
         This is an expensive call as it needs to call CourseGradeFactory if
         there is not already a LearnerCourseGradeMetrics record for the learner
@@ -259,6 +260,71 @@ class EnrollmentDataManager(models.Manager):
             defaults=defaults)
         return obj, created
 
+    def update_metrics(self, site, course_enrollment, force_update=False):
+        """
+        This is an expensive call as it needs to call CourseGradeFactory if
+        there is not already a LearnerCourseGradeMetrics record for the learner
+
+        """
+        date_for = utc_yesterday()
+
+        # check if we already have a record for the date for EnrollmentData
+
+        # Alternately, we could use a try/except on a 'get' call, however, this
+        # would be much slower for a bunch of new enrollments
+
+        # Should only be one even if we don't include the site in the query
+        # because course_id should be globally unique
+        # If course id is ever NOT globally unique, then we need to add site
+        # to the query
+        ed_recs = EnrollmentData.objects.filter(
+            user_id=course_enrollment.user_id,
+            course_id=str(course_enrollment.course_id))
+
+        if not ed_recs or ed_recs[0].date_for < date_for or force_update:
+            # We do the update
+            start_time = timeit.default_timer()
+            # get the progress data
+            ep = EnrollmentProgress(user=course_enrollment.user,
+                                    course_id=str(course_enrollment.course_id))
+            defaults = dict(
+                date_for=date_for,
+                is_completed=ep.is_completed(),
+                progress_percent=ep.progress_percent(),
+                points_possible=ep.progress.get('points_possible', 0),
+                points_earned=ep.progress.get('points_earned', 0),
+                sections_possible=ep.progress.get('sections_possible', 0),
+                sections_worked=ep.progress.get('sections_worked', 0),
+                is_enrolled=course_enrollment.is_active,
+                date_enrolled=course_enrollment.created,
+            )
+            elapsed = timeit.default_timer() - start_time
+            defaults['collect_elapsed'] = elapsed
+
+            ed_rec, created = self.update_or_create(
+                site=site,
+                user=course_enrollment.user,
+                course_id=str(course_enrollment.course_id),
+                defaults=defaults)
+            # create a new LCGM record
+            # if it already exists for the day
+            LearnerCourseGradeMetrics.objects.update_or_create(
+                site=ed_rec.site,
+                user=ed_rec.user,
+                course_id=ed_rec.course_id,
+                date_for=date_for,
+                defaults=dict(
+                    points_possible=ed_rec.points_possible,
+                    points_earned=ed_rec.points_earned,
+                    sections_worked=ed_rec.sections_worked,
+                    sections_possible=ed_rec.sections_possible,
+                    collect_elapsed=elapsed
+                )
+            )
+            return ed_rec, created
+        else:
+            return ed_recs[0], False
+
 
 @python_2_unicode_compatible
 class EnrollmentData(TimeStampedModel):
@@ -301,6 +367,9 @@ class EnrollmentData(TimeStampedModel):
     sections_worked = models.IntegerField()
     sections_possible = models.IntegerField()
 
+    # seconds it took to collect progress data
+    collect_elapsed = models.FloatField(null=True)
+
     objects = EnrollmentDataManager()
 
     class Meta:
@@ -324,7 +393,7 @@ class EnrollmentData(TimeStampedModel):
 
 
 class LearnerCourseGradeMetricsManager(models.Manager):
-    """Custom model manager for LearnerCourseGrades model
+    """Custom model manager for LearnerCourseGradeMetrics model
     """
     def latest_lcgm(self, user, course_id):
         """Gets the most recent record for the given user and course
@@ -414,9 +483,9 @@ class LearnerCourseGradeMetrics(TimeStampedModel):
     Purpose is primarliy to improve performance for the front end. In addition,
     data collected can be used for course progress over time
 
-    We're capturing data from figures.metrics.LearnerCourseGrades
+    We're capturing data from figures.progress.EnrollmentProgress
 
-    Note: We're probably going to move ``LearnerCourseGrades`` to figures.pipeline
+    Note: We're probably going to move ``EnrollmentProgress`` to figures.pipeline
     since that class will only be needed by the pipeline
 
     Even though this is for a course enrollment, we're mapping to the user
@@ -451,6 +520,9 @@ class LearnerCourseGradeMetrics(TimeStampedModel):
     points_earned = models.FloatField()
     sections_worked = models.IntegerField()
     sections_possible = models.IntegerField()
+
+    # seconds it took to collect progress data
+    collect_elapsed = models.FloatField(null=True)
 
     objects = LearnerCourseGradeMetricsManager()
 

--- a/figures/settings/lms_production.py
+++ b/figures/settings/lms_production.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 import os
 from celery.schedules import crontab
 
+FIGURES_DEFAULT_DAILY_TASK = 'figures.tasks.populate_daily_metrics'
+
 
 class FiguresRouter(object):
 
@@ -64,8 +66,10 @@ def update_celerybeat_schedule(
     https://stackoverflow.com/questions/51631455/how-to-route-tasks-to-different-queues-with-celery-and-django
     """
     if figures_env_tokens.get('ENABLE_DAILY_METRICS_IMPORT', True):
+        figures_daily_task = figures_env_tokens.get('DAILY_TASK',
+                                                    FIGURES_DEFAULT_DAILY_TASK)
         celerybeat_schedule_settings['figures-populate-daily-metrics'] = {
-            'task': 'figures.tasks.populate_daily_metrics',
+            'task': figures_daily_task,
             'schedule': crontab(
                 hour=figures_env_tokens.get('DAILY_METRICS_IMPORT_HOUR', 2),
                 minute=figures_env_tokens.get('DAILY_METRICS_IMPORT_MINUTE', 0),

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -134,7 +134,7 @@ def get_site_for_course(course_id):
             site = None
     else:
         # Operating in single site / standalone mode, return the default site
-        site = Site.objects.get(id=settings.SITE_ID)
+        site = default_site()
     return site
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -221,6 +221,20 @@ class StudentModuleFactory(DjangoModelFactory):
         2018,2,2, tzinfo=factory.compat.UTC))
 
 
+    @classmethod
+    def from_course_enrollment(cls, course_enrollment, **kwargs):
+        """Contruct a StudentModule  for the given CourseEnrollment
+
+        kwargs provides for additional optional parameters if you need to
+        override the default factory assignment
+        """
+        kwargs.update({
+            'student': course_enrollment.user,
+            'course_id': course_enrollment.course_id,
+            })
+        return cls(**kwargs)
+
+
 if OPENEDX_RELEASE == GINKGO:
     class CourseEnrollmentFactory(DjangoModelFactory):
         class Meta:

--- a/tests/models/test_enrollment_data_update_metrics.py
+++ b/tests/models/test_enrollment_data_update_metrics.py
@@ -1,0 +1,201 @@
+"""
+Basic tests for figures.models.EnrollmentData model
+
+Test scenarios we need to help verify the data model
+
+1. Learner doesn't have a CourseEnrollment (CE)
+2. Learner just signed up. Has a CE, no LearnerCourseGradeMetric (LCGM)
+3. Learner has CE and one LCGM
+4. Learner has CE and multiple LCGM
+5. Learner completed the course
+6. Learner is no longer active in the course (Note: this is only handled in
+   our data by the fact that the EnrollmentData.is_active field would be False)
+7+ The test scenrios we haven't identified yet
+
+
+Tests fail in Ginkgo due to
+    "TypeError: 'course' is an invalid keyword argument for this function"
+
+Which is interesting because other tests use CourseEnrollmentFactory(course=X)
+and they do not fail in Ginkgo. For now, skipping test in Ginkgo
+"""
+
+import pytest
+
+from mock import patch
+
+from django.contrib.sites.models import Site
+
+from figures.helpers import (
+    as_datetime, days_from, utc_yesterday
+)
+from figures.models import EnrollmentData, LearnerCourseGradeMetrics
+
+from tests.factories import (
+    CourseEnrollmentFactory,
+    CourseOverviewFactory,
+    EnrollmentDataFactory,
+    LearnerCourseGradeMetricsFactory,
+    OrganizationFactory,
+    OrganizationCourseFactory,
+    StudentModuleFactory)
+from tests.helpers import (
+    organizations_support_sites
+)
+
+if organizations_support_sites():
+    from tests.factories import UserOrganizationMappingFactory
+
+    def map_users_to_org(org, users):
+        """Convenience method to simplify test code
+        """
+        [UserOrganizationMappingFactory(user=user,
+                                        organization=org) for user in users]
+
+
+# @pytest.mark.skipif(OPENEDX_RELEASE == GINKGO, reason='Breaks on CourseEnrollmentFactory')
+@pytest.mark.django_db
+class TestUpdateMetrics(object):
+    """Test EnrollmentDataManager.update_metrics method
+
+    """
+    @pytest.fixture(autouse=True)
+    def setup(self, db, settings):
+
+        # Set up data that's the same for standalone or multisite
+        self.date_for = utc_yesterday()
+        self.site = Site.objects.first()
+        self.courses = [CourseOverviewFactory(), CourseOverviewFactory()]
+
+        # Two for "our" course, one for another course in the same site
+        self.enrollments = [
+            CourseEnrollmentFactory(course_id=self.courses[0].id),
+            CourseEnrollmentFactory(course_id=self.courses[0].id),
+            CourseEnrollmentFactory(course_id=self.courses[1].id),
+        ]
+
+        self.ce0_sm = StudentModuleFactory.from_course_enrollment(
+            self.enrollments[0],
+            created=as_datetime(self.date_for),
+            modified=as_datetime(self.date_for))
+
+        # Handle site mode specifices
+        if organizations_support_sites():
+            settings.FEATURES['FIGURES_IS_MULTISITE'] = True
+            self.org = OrganizationFactory(sites=[self.site])
+            for course in self.courses:
+                OrganizationCourseFactory(organization=self.org,
+                                          course_id=str(course.id))
+            map_users_to_org(self.org, [ce.user for ce in self.enrollments])
+
+            # For our tests, we focus on a single enrollment. We should not
+            # need to stand up other site data, but if we find we do need to,
+            # then here's the place to do it
+        else:
+            self.org = OrganizationFactory()
+
+    def setup_data_for_force_checks(self):
+        pass
+
+    def test_new_records_yesterday(self):
+        """Test new enrollment with first activity in the course yesterday
+        """
+        ce = self.enrollments[0]
+        the_enrollment = {
+            'site': self.site,
+            'user': self.enrollments[0].user,
+            'course_id': str(self.enrollments[0].course_id)
+        }
+        assert not EnrollmentData.objects.filter(**the_enrollment)
+
+        ed, created = EnrollmentData.objects.update_metrics(self.site, ce)
+
+        check_ed = EnrollmentData.objects.get(**the_enrollment)
+        lcgm = LearnerCourseGradeMetrics.objects.latest_lcgm(ce.user, ce.course_id)
+        assert check_ed == ed
+        assert created
+        assert check_ed.date_for == self.date_for
+        assert lcgm.date_for == self.date_for
+
+    def test_edrec_exists_older_lcgm(self):
+        ce = self.enrollments[0]
+        older_date = days_from(self.date_for, -2)
+
+        # Create existing Figures records
+        EnrollmentDataFactory(site=self.site,
+                              user=ce.user,
+                              course_id=str(ce.course_id),
+                              date_for=older_date)
+        older_lcgm = LearnerCourseGradeMetricsFactory(site=self.site,
+                                                      user=ce.user,
+                                                      course_id=str(ce.course_id),
+                                                      date_for=older_date)
+
+        # Make sure that the LCGM we created is the most recent one
+        assert LearnerCourseGradeMetrics.objects.latest_lcgm(ce.user,
+                                                             ce.course_id) == older_lcgm
+        # assert lcgm1 == older_lcgm
+        # run our code under test
+        ed, created = EnrollmentData.objects.update_metrics(self.site, ce)
+        # verify our Figures records are updated
+        after_lcgm = LearnerCourseGradeMetrics.objects.latest_lcgm(ce.user, ce.course_id)
+        after_ed = EnrollmentData.objects.get(site=self.site,
+                                              user=ce.user,
+                                              course_id=str(ce.course_id))
+        assert after_lcgm.date_for == self.date_for
+        assert after_ed.date_for == self.date_for
+
+    def test_exists_no_force(self):
+        ce = self.enrollments[0]
+        construct_kwargs = dict(
+            site=self.site,
+            user=ce.user,
+            course_id=str(ce.course_id),
+            date_for=self.date_for)
+        before_ed = EnrollmentDataFactory(**construct_kwargs)
+        LearnerCourseGradeMetricsFactory(**construct_kwargs)
+        with patch('figures.models.EnrollmentProgress._get_progress') as get_prog:
+            ed, created = EnrollmentData.objects.update_metrics(self.site, ce)
+            assert not get_prog.called
+            assert ed == before_ed
+
+    def test_force_update(self):
+        ce = self.enrollments[0]
+
+        # Create existing Figures records
+        # We only need to assign one progress value but we assign the possible
+        # and earned for one to make sure that the earned is not more than the
+        # possible. We arbitrarily choose points. We could have also chosen
+        # sections or assigned both
+        construct_kwargs = dict(
+            site=self.site,
+            user=ce.user,
+            course_id=str(ce.course_id),
+            date_for=self.date_for,
+            points_earned=5,
+            points_possible=10)
+        EnrollmentDataFactory(**construct_kwargs)
+        before_lcgm = LearnerCourseGradeMetricsFactory(**construct_kwargs)
+
+        fake_progress = dict(points_possible=50,
+                             points_earned=25,
+                             sections_possible=10,
+                             sections_worked=5)
+
+        with patch('figures.models.EnrollmentProgress._get_progress', return_value=fake_progress):
+            ed, created = EnrollmentData.objects.update_metrics(self.site, ce, force_update=True)
+
+        # verify our Figures records are updated
+        lcgm = LearnerCourseGradeMetrics.objects.latest_lcgm(ce.user, ce.course_id)
+        check_ed = EnrollmentData.objects.get(site=self.site,
+                                              user=ce.user,
+                                              course_id=str(ce.course_id))
+        assert check_ed == ed
+        assert not created
+        assert check_ed.date_for == self.date_for
+        assert check_ed.points_earned == fake_progress['points_earned']
+        assert lcgm.date_for == self.date_for
+        assert lcgm.id == before_lcgm.id
+        # We only need to check one of the progress fields to know it was updated
+        assert lcgm.points_earned == fake_progress['points_earned']
+        # import pdb; pdb.set_trace()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -22,6 +22,7 @@ from figures.helpers import (
     previous_months_iterator,
     first_last_days_for_month,
     import_from_path,
+    utc_yesterday,
     )
 
 from tests.factories import COURSE_ID_STR_TEMPLATE
@@ -206,6 +207,7 @@ class TestMonthIterator(object):
         vals = list(previous_months_iterator(month_for, months_back))
         assert vals == expected_vals
 
+
 def test_first_last_days_for_month():
     month_for = '2/2020'
     month = 2
@@ -244,3 +246,15 @@ def test_import_from_bad_syntax():
     with pytest.raises(ValueError):
         # Malformed path
         import_from_path(utc_tz_path)
+
+
+def test_utc_yesterday():
+    """Basic sanity check and test coverage using live time
+
+    If we find a need or wante to get elaborate, we test a specific time for
+    any time by with monkeypatch/mock of `utcnow()` call in `figures.helpers`
+    If it is for a need because the expected and actual do not match up, then
+    document why.
+    """
+    expected = datetime.datetime.utcnow().date() - datetime.timedelta(days=1)
+    assert utc_yesterday() == expected


### PR DESCRIPTION
This PR contains updates to Figures as prerequisites to adding the second switchable workflow

Each PR has it's own description and context. So please read the changes in calendar order so you see the details to the story.

## Why this PR exists and high level story

1. We need to improve Figures daily metrics collection job  (the "daily pipeline") performance for one of our standalone deployments
2. The existing daily job is working on Tahoe and we don't want to break it
3. So we add a second daily job workflow
4. We enable the deployment to choose which workflow to run on a setting in Figures server-vars
5. After we prove the robustness of the second workflow, we will deprecate and then remove the original workflow

## What's the scope of this PR

1. This PR contains code refactoring and changes needed to support the new workflow
2. This PR does NOT contain the actual second workflow code
3. These are broken up into two PRs for readability

## What's IN this PR?

1. Added a Figures `ENV_TOKENS` flag to choose an override task to kick of the daily Celery top level task or use the default one: https://github.com/appsembler/figures/commit/926cd7c5bb22dd1670ee221de473c071e4aad1d8
2. Minor code cleanup found along the way that is opportune to include in this PR: https://github.com/appsembler/figures/commit/83687ca54b77d90dfaafaeb2a2301ea352ece5f6
3. Because it can be confusing to get the specific calendar day (24 hour period starting at 00:00 UTC) for "yesterdays" data collection, added a convenience function to `figures.helpers`: https://github.com/appsembler/figures/commit/42ce02d575ba9cc6004d4dde91699252daf9f7f0
4. Found a bug in Figures devsite settings when I needed to create a migration, so fixed that here: https://github.com/appsembler/figures/commit/5a5ff31e03ed6a6ca18e9502effcfb589cd78b13
5. And the most important part of this PR, updated metrics collection handling to encapsulate and abstract "per enrollment" progress collection here: https://github.com/appsembler/figures/commit/c6693fe12d7873dd94017c438c5ac32cd427f953

It's the last PR that is most important (I repeat myself because it is the most important. There, I've done it again). Anyway, with the new workflow, we will invert the relationship of `LearnerCourseGradeMetrics` (LCGM) and `EnrollmentData` where we write first to `EnrollmentData` (let's call him "ed") and use ed as the primary for data retrieval in the API (we started that already when we introduced ed as a model in figures). LCGM gets pushed back to be a historical record to track the time series per-enrollment performance

But we're not there yet, lots of refactoring to do to get there. What no. 5 commit above does is abstract this relationship from the rest of Figures and isolate the progress retrieval to make Figures safer, faster and more fun to program on
