### PR TITLE
Fix enrollment data backfill Django management command

### DIFF
--- a/figures/management/commands/backfill_figures_enrollment_data.py
+++ b/figures/management/commands/backfill_figures_enrollment_data.py
@@ -1,30 +1,153 @@
 """This Django management command updates Figures EnrollmentData records
 
-Running this will trigger figures.tasks.update_enrollment_data for every site
+Running this will trigger figures.tasks.backfill_enrollment_data_for_course
+
+Specific sites or courses need to be identified. Running without either of these
+parameters will raise a CommandError stating that one of these parameters are
+needed.
+
+This Django management command does not default to running update on every
+enrollment because that could trigger a heavy and long load for larger deployments
+that require many EnrollmentData records to be updated.
+
+To specify sites, use the `--sites` parameter, followed by a space delimited list
+of domain names. Example:
+
+```
+backfill_figures_enrollment_data --sites heres-a-site.com another-site.com
+```
+
+To specify courses, use the `--courses` paramter, followed by a space delimited
+list of course id string. Example:
+
+
+### Important
+
+* The above do not include the full Django management command
+* These are run for the LMS instance
+
+Either `--sites` or `--courses` parameter needs to be
+
 unless the '--site' option is used. Then it will update just that site
+
+For potential improvements to this management command, see here:
+
+* https://github.com/appsembler/figures/issues/435
 """
 from __future__ import print_function
 from __future__ import absolute_import
 
 from textwrap import dedent
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand, CommandError
 
-from figures.management.base import BaseBackfillCommand
-from figures.tasks import update_enrollment_data_for_site
+from figures.compat import CourseOverview
+from figures.helpers import as_course_key
+from figures.sites import site_course_ids
+from figures.tasks import backfill_enrollment_data_for_course
 
 
-class Command(BaseBackfillCommand):
+class Command(BaseCommand):
     """Backfill Figures EnrollmentData model.
+
+    This Django managmenet command provides a basic CLI to create and update
+    Figures `EnrollmentData` records.
+
+    It filters on either sites or course ids. Because this is potentially a
+    resource intensive command, it requires identifying specific sites or
+    course ids. Yes, there's improvement for this.
+
+    * If both sites and courses parameters are used, the sites are ignored
+    * If there are any invalid site names or primary keys, the command will fail
+      with the Django model's `DoesNotExist` exception
+    * If there are any invalid course ids the command will fail with
+      `DoesNotExist` if the course id has a valid structure but the course is
+      not found and with `InvalidKeyErro` if the course id does not have a valid
+      structure (CourseKey.from_string(course_id) fails)
+
+    For potential improvements, read (and contribute if you want) here:
+
+    * https://github.com/appsembler/figures/issues/435
     """
     help = dedent(__doc__).strip()
 
+    def get_sites(self, options):
+        """Returns a list of Site objects
+
+        Raises `DoesNotExist` if a site in the list is missing
+        If no sites are specified, returns an empty list
+        """
+        sites = []
+        for site_identifier in options.get('sites', []):
+            sites.append(Site.objects.get(domain=site_identifier))
+        return set(sites)
+
+    def get_course_ids(self, options):
+        """Return a validated list of course id strings.
+
+        If no courses are specified, returns an empty list
+
+        Raises `DoesNotExist` or `InvalidKeyError` exceptions if a course id
+        is either malformed or is not malformed, but does not exist
+        """
+        course_ids = []
+        for cid_str in options.get('courses', []):
+            course_overview = CourseOverview.objects.get(id=as_course_key(cid_str))
+            # we got a course overview object. Otherwise, we'd fail here with
+            # `InvalidKeyError` or `DoesNotExist` error
+            # While we could just use `cid_str`, this has us use the object
+            # returned. We do NOT want to check if the key exists because we
+            # want to let the user know there was a problem with a course id
+            course_ids.append(str(course_overview.id))
+        return course_ids
+
+    def update_enrollments(self, course_ids, use_celery=True):
+        for course_id in course_ids:
+            if use_celery:
+                # Call the Celery task with delay
+                backfill_enrollment_data_for_course.delay(str(course_id))
+            else:
+                # Call the Celery task immediately
+                backfill_enrollment_data_for_course(str(course_id))
+
+    def add_arguments(self, parser):
+        """
+
+        If site domain or id or set of ides are provided, but no course or
+        courses provided, runs for all courses in the site
+
+        If a course id or list of course ids provided, processes those courses
+        If a site
+        """
+        parser.add_argument('--sites',
+                            nargs='+',
+                            default=[],
+                            help='backfill a specific site. provide id or domain name')
+        parser.add_argument('--courses',
+                            nargs='+',
+                            default=[],
+                            help='backfill a specific course. provide course id string')
+        parser.add_argument('--use-celery',
+                            action='store_true',
+                            default=True,
+                            help='Run with Celery worker. Set to false to run in app space ')
+
     def handle(self, *args, **options):
         print('BEGIN: Backfill Figures EnrollmentData')
+        sites = self.get_sites(options)
+        course_ids = self.get_course_ids(options)
+        use_celery = options['use_celery']
 
-        for site_id in self.get_site_ids(options['site']):
-            print('Updating EnrollmentData for site {}'.format(site_id))
-            if options['no_delay']:
-                update_enrollment_data_for_site(site_id=site_id)
-            else:
-                update_enrollment_data_for_site.delay(site_id=site_id)  # pragma: no cover
+        # Would it benefit to implement a generator method to yield the course id?
+        if course_ids:
+            self.update_enrollments(course_ids, use_celery=use_celery)
+
+        elif sites:
+            for site in sites:
+                course_ids = site_course_ids(site)
+                self.update_enrollments(course_ids, use_celery=use_celery)
+
+        else:
+            raise CommandError('You need to provide at least one site or course to update')
 
         print('DONE: Backfill Figures EnrollmentData')

--- a/figures/management/commands/backfill_figures_monthly_metrics.py
+++ b/figures/management/commands/backfill_figures_monthly_metrics.py
@@ -9,8 +9,10 @@ from textwrap import dedent
 
 from django.contrib.sites.models import Site
 
-from figures.backfill import backfill_monthly_metrics_for_site
+from figures.pipeline.backfill import backfill_monthly_metrics_for_site
 from figures.management.base import BaseBackfillCommand
+
+assert 0, "This command needs to be reworked both for performance and correctness"
 
 
 def backfill_site(site, overwrite, use_raw_sql):

--- a/figures/pipeline/backfill.py
+++ b/figures/pipeline/backfill.py
@@ -19,6 +19,7 @@ from figures.pipeline.site_monthly_metrics import fill_month
 from figures.models import EnrollmentData
 
 
+# This function called just by mgmt command, backfill_figures_monthly_metrics.py
 def backfill_monthly_metrics_for_site(site, overwrite=False, use_raw_sql=False):
     """Backfill specified months' historical site metrics for the specified site
     """

--- a/tests/commands/test_backfill_figures_enrollment_data_command.py
+++ b/tests/commands/test_backfill_figures_enrollment_data_command.py
@@ -1,0 +1,106 @@
+"""Test Figures Django management commands
+"""
+from __future__ import absolute_import
+
+import pytest
+import mock
+
+from django.core.management import call_command
+
+from tests.factories import CourseOverviewFactory, SiteFactory
+
+
+@pytest.mark.django_db
+class TestBackfillEnrollmentDataCommand(object):
+    """Tests Django managmeent command, 'backfill_figures_enrollment_data'
+
+    Alternate testing approach
+
+    * Directly test the `Command.update_enrollments(...) method to make sure
+      this method is correct
+    * Mock `Command.update_enrollments(...)` for testing each of the following
+      cases:
+        * has one site domain, has two site domains
+        * has one course id, has two course ids
+        * has one or more site domains, and one or more courses
+            * expects to ignore the sites arg and only process the courses arg
+    """
+    TASK = 'figures.tasks.backfill_enrollment_data_for_course'
+    MANAGEMENT_COMMAND = 'backfill_figures_enrollment_data'
+
+    @pytest.mark.parametrize('domains', [
+        ['alpha.test'], ['alpha.test', 'bravo.test']
+    ])
+    @pytest.mark.parametrize('delay_suffix, do_delay', [
+        ('', False), ('.delay', True)
+    ])
+    def test_backfill_with_sites_arg(self, domains, delay_suffix, do_delay):
+        sites = [SiteFactory(domain=domain) for domain in domains]
+        courses = [CourseOverviewFactory() for _ in range(2)]
+        course_ids = [str(obj.id) for obj in courses]
+        courses_for_sites = [course_ids for _ in range(len(domains))]
+        calls = []
+        for _ in range(len(sites)):
+            calls += [mock.call(course_id) for course_id in course_ids]
+        kwargs = {'sites': domains, 'use_celery': do_delay}
+
+        with mock.patch('figures.sites.site_course_ids') as mock_site_course_ids:
+            # Build thed list of the course_ids returned for each call to `site_course_ids`
+            mock_site_course_ids.return_value = courses_for_sites
+            with mock.patch(self.TASK + delay_suffix) as mock_task:
+                call_command(self.MANAGEMENT_COMMAND, **kwargs)
+                assert mock_task.has_calls(calls)
+
+    @pytest.mark.parametrize('course_ids', [
+        ['course-v1:TestOrg+T01+run'],
+        ['course-v1:TestOrg+T01+run', 'course-v1:TestOrg+T02+run'],
+    ])
+    def test_backfill_with_courses_arg_immediate(self, course_ids):
+        """Test called with courses arg and not run in Celery worker
+
+        This tests that the expected task function is called with specific
+        parameters and the `.delay(course_id)` is not called.
+
+        This and the following function are almost identical.
+        They can be merged as one test method, but for now left as two
+        test methods initially for readability and the additional development
+        time to implement it.
+
+        But, should we merge them, we add an additional parametrize decorator
+        like so:
+        ```
+        @pytest.mark.parametrize('delay_suffix, delay_flag', [
+            ('', False), ('.delay', True)
+        ])
+        ```
+        And then we abstract the nested mocks to swap the `.has_calls` and
+        `not called` checks (which might require a conditional)
+        """
+        [CourseOverviewFactory(id=cid) for cid in course_ids]
+        kwargs = {'courses': course_ids, 'use_celery': False}
+        calls = [mock.call(course_id) for course_id in course_ids]
+
+        with mock.patch(self.TASK) as mock_task:
+            with mock.patch(self.TASK + '.delay') as mock_task_delay:
+                call_command(self.MANAGEMENT_COMMAND, **kwargs)
+                assert mock_task.has_calls(calls)
+                assert not mock_task_delay.called
+
+    @pytest.mark.parametrize('course_ids', [
+        ['course-v1:TestOrg+T01+run'],
+        ['course-v1:TestOrg+T01+run', 'course-v1:TestOrg+T02+run'],
+    ])
+    def test_backfill_with_courses_arg_delay(self, course_ids):
+        """Test called with courses arg and run in Celery worker
+
+        See comment in the test method immediate above this one.
+        """
+        [CourseOverviewFactory(id=cid) for cid in course_ids]
+        kwargs = {'courses': course_ids, 'use_celery': True}
+        calls = [mock.call(course_id) for course_id in course_ids]
+
+        with mock.patch(self.TASK) as mock_task:
+            with mock.patch(self.TASK + '.delay') as mock_task_delay:
+                call_command(self.MANAGEMENT_COMMAND, **kwargs)
+                assert mock_task_delay.has_calls(calls)
+                assert not mock_task.called

--- a/tests/pipeline/test_backfill.py
+++ b/tests/pipeline/test_backfill.py
@@ -11,7 +11,7 @@ from six.moves import zip
 from django.db import connection
 from django.utils.timezone import utc
 
-from figures.backfill import backfill_monthly_metrics_for_site
+from figures.pipeline.backfill import backfill_monthly_metrics_for_site
 from figures.models import SiteMonthlyMetrics
 from tests.factories import (
     CourseOverviewFactory,

--- a/tests/tasks/test_backfill_tasks.py
+++ b/tests/tasks/test_backfill_tasks.py
@@ -1,0 +1,20 @@
+"""Test Figures backfill Celery tasks
+"""
+from __future__ import absolute_import
+
+from figures.tasks import backfill_enrollment_data_for_course
+
+from tests.factories import EnrollmentDataFactory
+
+
+def test_backfill_enrollment_data_for_course(transactional_db, monkeypatch):
+    """
+    The Celery task is a simple wrapper around the pipeline function
+    """
+    course_id = 'course-v1:SomeOrg+SomeNum+SomeRun'
+    ed_recs = [EnrollmentDataFactory() for _ in range(2)]
+
+    func_path = 'figures.tasks.update_enrollment_data_for_course'
+    monkeypatch.setattr(func_path, lambda course_id: ed_recs)
+    ed_ids = backfill_enrollment_data_for_course(course_id)
+    assert set(ed_ids) == set([obj.id for obj in ed_recs])


### PR DESCRIPTION
Update `backfill_figures_enrollment_data` Django management command to use new workflow

* With basic test coverage now
* Moved `figures.backfill` to `figures.pipeline.backfill` because that's where it belongs

At the core, this is really just a convenience wrapper around `figures.tasks.backfill_enrollment_data_for_course`

As we use it, we'll iterate on CLI to improve usability.
