### PR TITLE
Update GH workflows tests, adding pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: figures tests
 
-on: push
+on:
+    push:
+        branches:
+            - main
+            - develop/maple
+    pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Before this commit, a PR on figures from a fork will not trigger the Tox tests. This PR does the following

* Only run 'on push' for specified branches (main and develop/maple)
* Trigger 'on pull_request' (for all PRs)

The update here matches that of other repos we have, such as `edx-platform`, `edx-theme-customers`, `course-access-group`