### PR TITLE
Set default pytest mock to juniper

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 DJANGO_SETTINGS_MODULE = devsite.test_settings
 
 norecursedirs = .* docs requirements
-python_paths = devsite mocks/hawthorn
+python_paths = devsite mocks/juniper
 testpaths = ./tests


### PR DESCRIPTION
This should have been included with this commit:

* https://github.com/appsembler/figures/pull/427/commits/5a5ff31e03ed6a6ca18e9502effcfb589cd78b13

This commit also resolves this problem of missing `devsite/.env` file: https://github.com/appsembler/figures/issues/331

So we can run `pytest` without the need to create the `.env` file
