### PR TITLE
MAU 2 - Add Monthly Active Enrollment Model

### DIFF
--- a/figures/admin.py
+++ b/figures/admin.py
@@ -120,6 +120,18 @@ class LearnerCourseGradeMetricsAdmin(UserRelatedMixin, admin.ModelAdmin):
     read_only_fields = ('user', 'user_link')
 
 
+@admin.register(figures.models.MonthlyActiveEnrollment)
+class MonthlyActiveEnrollmentAdmin(admin.ModelAdmin):
+    """Defines the admin interface for the MonthlyActiveEnrollment model
+    """
+    list_display = ('id', 'site', 'course_id', 'user', 'month_for')
+    list_filter = (
+        ('site', RelatedOnlyDropdownFilter),
+        ('course_id', AllValuesDropdownFilter),
+        ('user', RelatedOnlyFieldListFilter),
+        'month_for')
+
+
 @admin.register(figures.models.PipelineError)
 class PipelineErrorAdmin(admin.ModelAdmin):
     """Defines the admin interface for the PipelineError model

--- a/figures/migrations/0017_add_monthly_active_enrollment_model.py
+++ b/figures/migrations/0017_add_monthly_active_enrollment_model.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django import VERSION as DJANGO_VERSION
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+import django.utils.timezone
+import model_utils.fields
+
+
+class Migration(migrations.Migration):
+    if DJANGO_VERSION[0:2] == (1,8):
+        dependencies = [
+            migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+            ('sites', '0001_initial'),
+            ('figures', '0016_add_collect_elapsed_to_ed_and_lcgm'),
+        ]
+    else:  # Assuming 1.11+
+        dependencies = [
+            migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+            ('sites', '0002_alter_domain_unique'),
+            ('figures', '0016_add_collect_elapsed_to_ed_and_lcgm'),
+        ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MonthlyActiveEnrollment',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
+                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
+                ('course_id', models.CharField(max_length=255, db_index=True)),
+                ('month_for', models.DateField(db_index=True)),
+                ('site', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='sites.Site')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'ordering': ['-month_for', 'site', 'course_id'],
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name='monthlyactiveenrollment',
+            unique_together=set([('site', 'course_id', 'user', 'month_for')]),
+        ),
+    ]

--- a/figures/models.py
+++ b/figures/models.py
@@ -4,8 +4,9 @@ TODO: Create a base "SiteModel" or a "SiteModelMixin"
 """
 
 from __future__ import absolute_import
-from datetime import date
+from datetime import datetime, date
 from time import time
+import six
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -568,6 +569,68 @@ class LearnerCourseGradeMetrics(TimeStampedModel):
     def completed(self):
         return (self.sections_worked > 0 and
                 self.sections_worked == self.sections_possible)
+
+
+class MonthlyActiveEnrollmentManager(models.Manager):
+    """Model manager for MonthlyActiveEnrollment
+
+    TODO:
+    * Add query convenience methods to get aggregate metrics,
+        * mau_for_site_and_month(self, site, month_for or year and month)
+        * mau_for_course_and_month(self, course, month_for or year and month)
+        * current month site MAU
+        * current month course MAU
+    """
+
+    def add_mae(self, site_id, course_id, user_id, date_for=None, overwrite=False):
+        """
+        We use 'date_for' instead of 'month_for' to enforce the day of month for
+        the 'month_for' field
+        """
+        if date_for:
+            month_for = date(year=date_for.year, month=date_for.month, day=1)
+        else:
+            today = datetime.utcnow()
+            month_for = date(year=today.year, month=today.month, day=1)
+        if not overwrite:
+            try:
+                obj = self.get(
+                    site_id=site_id,
+                    course_id=six.text_type(course_id),  # noqa: F821
+                    user_id=user_id,
+                    month_for=month_for)
+                return (obj, False)
+            except MonthlyActiveEnrollment.DoesNotExist:
+                pass
+
+        return self.update_or_create(
+            site_id=site_id,
+            course_id=six.text_type(course_id),  # noqa: F821
+            user_id=user_id,
+            month_for=month_for)
+
+
+@python_2_unicode_compatible
+class MonthlyActiveEnrollment(TimeStampedModel):
+    """Capture enrollment activity for a given month
+
+    An enrollment is a unique user+course pair
+
+    """
+    site = models.ForeignKey(Site, on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    course_id = models.CharField(max_length=255, db_index=True)
+    month_for = models.DateField(db_index=True)
+
+    objects = MonthlyActiveEnrollmentManager()
+
+    class Meta:
+        ordering = ['-month_for', 'site', 'course_id']
+        unique_together = ['site', 'course_id', 'user', 'month_for']
+
+    def __str__(self):
+        return "id:{}, site:{} course_id:{} user:{} month_for:{},".format(
+            self.id, self.site.domain, self.course_id, self.user.username, self.month_for)
 
 
 @python_2_unicode_compatible

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def sm_test_data(db):
 
 
 @pytest.mark.django_db
-def make_site_data(num_users=3, num_courses=2):
+def make_site_data(num_users=3, num_courses=2, create_enrollments=True):
 
     site = SiteFactory()
     if organizations_support_sites():
@@ -74,14 +74,15 @@ def make_site_data(num_users=3, num_courses=2):
 
     users = [UserFactory() for i in range(num_users)]
 
-    enrollments = []
-    for i, user in enumerate(users):
-        # Create increasing number of enrollments for each user, maximum to one less
-        # than the number of courses
-        for j in range(i):
-            enrollments.append(
-                CourseEnrollmentFactory(course=courses[j-1], user=user)
-            )
+    if create_enrollments:
+        enrollments = []
+        for i, user in enumerate(users):
+            # Create increasing number of enrollments for each user, maximum to one less
+            # than the number of courses
+            for j in range(i):
+                enrollments.append(
+                    CourseEnrollmentFactory(course=courses[j-1], user=user)
+                )
 
     if organizations_support_sites():
         for course in courses:
@@ -91,13 +92,16 @@ def make_site_data(num_users=3, num_courses=2):
         # Set up user mappings
         map_users_to_org(org, users)
 
-    return dict(
+    data = dict(
         site=site,
         org=org,
         courses=courses,
         users=users,
         enrollments=enrollments,
     )
+    if create_enrollments:
+        data['enrollments'] = enrollments
+    return data
 
 
 @pytest.fixture

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -40,6 +40,7 @@ from figures.models import (
     CourseMauMetrics,
     EnrollmentData,
     LearnerCourseGradeMetrics,
+    MonthlyActiveEnrollment,
     SiteDailyMetrics,
     SiteMonthlyMetrics,
     SiteMauMetrics,
@@ -354,6 +355,17 @@ class LearnerCourseGradeMetricsFactory(DjangoModelFactory):
     points_earned = 15.0
     sections_worked = 5
     sections_possible = 10
+
+
+class MonthlyActiveEnrollmentFactory(DjangoModelFactory):
+    class Meta:
+        model = MonthlyActiveEnrollment
+    site = factory.SubFactory(SiteFactory)
+    month_for = factory.Sequence(lambda n: (
+        datetime.date(2020, 6, 1) - relativedelta(months=n)))
+    course_id = factory.Sequence(lambda n:
+        'course-v1:StarFleetAcademy+SFA{}+2161'.format(n))
+    user = factory.SubFactory(UserFactory)
 
 
 class SiteDailyMetricsFactory(DjangoModelFactory):

--- a/tests/models/test_monthly_active_enrollment_model.py
+++ b/tests/models/test_monthly_active_enrollment_model.py
@@ -1,0 +1,122 @@
+"""Tests MonthlyActiveEnrollment model
+
+Initially just basic testing for coverage
+"""
+from __future__ import absolute_import
+import six
+from datetime import date
+import pytest
+
+from figures.models import MonthlyActiveEnrollment
+
+from tests.factories import MonthlyActiveEnrollmentFactory
+from tests.helpers import organizations_support_sites
+from tests.conftest import make_site_data
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def mae_test_data(db, settings):
+    """
+    Because Figures `MonthlyActiveEnrollment` is decoupled from course data,
+    we do not need to create enrollments
+    """
+    if organizations_support_sites():
+        settings.FEATURES['FIGURES_IS_MULTISITE'] = True
+
+    our_site_data = make_site_data(create_enrollments=False)
+    other_site_data = make_site_data(create_enrollments=False)
+    return dict(us=our_site_data, them=other_site_data)
+
+
+@pytest.mark.parametrize('overwrite, expect_created', [
+    (False, True),
+    (True, True),
+])
+def test_add_mae_new_overwrite_option(mae_test_data,
+                                      overwrite,
+                                      expect_created):
+    """
+    Test 'overwrite' option when adding a monthly active enrollment
+    """
+    # Arrange
+    us = mae_test_data['us']
+    course_id = us['courses'][0].id
+    user = us['users'][0]
+    assert not MonthlyActiveEnrollment.objects.count()
+
+    # Act
+    obj, created = MonthlyActiveEnrollment.objects.add_mae(
+        site_id=us['site'].id,
+        course_id=course_id,
+        user_id=user.id,
+        overwrite=overwrite)
+
+    # Assert
+    assert obj
+    assert created == expect_created
+    assert MonthlyActiveEnrollment.objects.count() == 1
+
+
+@pytest.mark.parametrize('overwrite, expect_created', [
+    (False, False),
+    (True, False),
+])
+def test_add_mae_existing_overwrite_option(mae_test_data,
+                                           overwrite,
+                                           expect_created):
+    """
+    Test 'overwrite' option when adding to an existing monthly active enrollment
+    """
+
+    # Arrange
+    us = mae_test_data['us']
+    course_id = us['courses'][0].id
+    user = us['users'][0]
+    date_for = date.today()
+    month_for = date(year=date_for.year, month=date_for.month, day=1)
+    mae = MonthlyActiveEnrollmentFactory(
+        site=us['site'],
+        course_id=six.text_type(course_id),
+        user=user,
+        month_for=month_for)
+
+    assert MonthlyActiveEnrollment.objects.count() == 1
+
+    # Act
+    obj, created = MonthlyActiveEnrollment.objects.add_mae(
+        site_id=us['site'].id,
+        course_id=course_id,
+        user_id=user.id,
+        overwrite=overwrite)
+
+    # Assert
+    assert obj and obj.id and obj.id == mae.id
+    assert created == expect_created
+    assert MonthlyActiveEnrollment.objects.count() == 1
+
+
+def test_add_mae_with_date_for(mae_test_data):
+    """
+    Test using the current date as 'date_for'
+    """
+    # Arrange
+    us = mae_test_data['us']
+    course_id = us['courses'][0].id
+    user = us['users'][0]
+    assert not MonthlyActiveEnrollment.objects.count()
+    date_for = date.today()
+    month_for = date(year=date_for.year, month=date_for.month, day=1)
+
+    # Act
+    obj, created = MonthlyActiveEnrollment.objects.add_mae(
+        site_id=us['site'].id,
+        course_id=course_id,
+        user_id=user.id,
+        date_for=date_for)
+
+    # Assert
+    assert obj and obj.id
+    assert created
+    assert MonthlyActiveEnrollment.objects.count() == 1
+    assert obj.month_for == month_for

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -14,6 +14,7 @@ from figures.models import (
     SiteDailyMetrics,
     SiteMonthlyMetrics,
     LearnerCourseGradeMetrics,
+    MonthlyActiveEnrollment,
     PipelineError,
     CourseMauMetrics,
     )
@@ -39,6 +40,7 @@ class TestModelAdminRepresentations(object):
             (SiteDailyMetrics, figures.admin.SiteDailyMetricsAdmin),
             (SiteMonthlyMetrics, figures.admin.SiteMonthlyMetricsAdmin),
             (LearnerCourseGradeMetrics, figures.admin.LearnerCourseGradeMetricsAdmin),
+            (MonthlyActiveEnrollment, figures.admin.MonthlyActiveEnrollmentAdmin),
             (PipelineError, figures.admin.PipelineErrorAdmin),
             (CourseMauMetrics, figures.admin.CourseMauMetricsAdmin),
         ])


### PR DESCRIPTION
# What's this PR about?

This is the first part of revamping how Figures captures monthly active users. At the core of this is a new model, `MonthlyActiveEnrollment` that says if a given user was active in a course for a given month, a unique user + course aka 'enrollment', so we simply call it 'monthly active enrollment'. This model then forms a foundation to quickly query for such things as
* active users in a site for a given month or set of months
* active users in a cohort for a given month or set of months
* which courses a user was active in for a given month or set of months

We're generally following this design: https://appsembler.atlassian.net/wiki/spaces/RT/pages/350552808

# What's in this PR?

* Adds new model, figures.models.MonhtlyActiveEnrollment
    * This model exists to capture user activity in a course in a month
    * This forms a foundation from which per-user or per-course or per-site monthly active users can be derived
* Added model unit tests and updated test infra for support
* Add admin interface for MonthlyActiveEnrollment and update admin test

# What's next?

After this PR is merged, the models won't update right away. We're adding Django signals to trigger the check and creating of a `MonthlyActiveEnrollment` if it doesn't exist. The signals will be configurable, at least at the deployment level via `server-vars` with the option to toggle on/off at the site level