### PR TITLE
Enable daily metrics models backfill of historical data in platform, but not progress

### DIFF
--- a/figures/course.py
+++ b/figures/course.py
@@ -121,3 +121,18 @@ class Course(object):
         user_ids = sm.values('student_id').distinct()
         return CourseEnrollment.objects.filter(course_id=self.course_key,
                                                user_id__in=user_ids).distinct()
+
+    def first_enrollment_timestamp(self):
+        """Get the `created` datetime of the first enrollment in this course
+
+        If there are no enrollments, then `None` is returned
+
+        We can improve this a bit by caching the query in self.enrollments
+        property method, but for now we do this to avoid a second database query
+        if there are no enrollments
+        """
+        enrollments = self.enrollments
+        if enrollments:
+            return enrollments.earliest('created').created
+        else:
+            return None

--- a/figures/management/commands/backfill_figures_daily_metrics.py
+++ b/figures/management/commands/backfill_figures_daily_metrics.py
@@ -11,14 +11,14 @@ from textwrap import dedent
 
 from dateutil.rrule import rrule, DAILY
 
-from figures.management.base import BaseBackfillCommand
-from figures.tasks import (
-    populate_daily_metrics,
-    experimental_populate_daily_metrics
-)
+from django.core.management.base import BaseCommand, CommandError
+
+from figures.helpers import as_date
+from figures.sites import Site
+from figures.pipeline.backfill import backfill_daily_metrics_for_site_and_date
 
 
-class Command(BaseBackfillCommand):
+class Command(BaseCommand):
     '''Populate Figures daily metrics models (``CourseDailyMetrics`` and ``SiteDailyMetrics``).
     Note that correctly populating cumulative user and course count for ``SiteDailyMetrics``
     relies on running this sequentially forward from the first date for which StudentModule records
@@ -27,57 +27,83 @@ class Command(BaseBackfillCommand):
 
     help = dedent(__doc__).strip()
 
+    def do_backfill(self, site, date_for, **kwargs):
+        """Thin wrapper around backfill function to handle parameters
+        """
+        if kwargs.get('skip_sdm', False):
+            process_sdm = False
+        else:
+            process_sdm = True
+        logdir = kwargs.get('logdir', None)
+        force_update = kwargs.get('force_update', False)
+
+        return 'nop'
+        return backfill_daily_metrics_for_site_and_date(site,
+                                                        date_for,
+                                                        process_sdm=process_sdm,
+                                                        logdir=logdir,
+                                                        force_update=force_update)
+
+    def get_site(self, options):
+        """Return a Site object matching the command line arg
+
+        The 'site' option can be a domain name (sans protocol) or the site
+        record primary key
+        """
+        identifier = options['site']
+        try:
+            filter_arg = dict(pk=int(identifier))
+        except ValueError:
+            filter_arg = dict(domain=identifier)
+        return Site.objects.get(**filter_arg)
+
+    def get_dates(self, options):
+        """Return a list of dates
+        """
+        if options['date'] and options['date_range']:
+            raise CommandError(
+                'Select either "--date" or "--date-range" option, but not both')
+        if not options['date'] and not options['date_range']:
+            raise CommandError(
+                'You need to select one of "--date" or "--date-range" parameters')
+        if options['date']:
+            return [as_date(options['date'])]
+        else:
+            dates = sorted([as_date(rec) for rec in options['date_range']])
+            # The '--date-range' CLI argument enforces two values
+            return [dt.date() for dt in rrule(freq=DAILY,
+                                              dtstart=dates[0],
+                                              until=dates[1])]
+
     def add_arguments(self, parser):
-        parser.add_argument(
-            '--experimental',
-            action='store_true',
-            default=False,
-            help=('Run with Celery workflows (Warning: This is still under'
-                  ' development and likely to get stuck/hung jobs')
-        )
-        super(Command, self).add_arguments(parser)
+        parser.add_argument('site', help='Site domain or id')
+
+        parser.add_argument('--date', help='Run backfill for a single date')
+        parser.add_argument('--date-range', nargs=2,
+                            help='Run backfill from a start date to an end date')
+
+        # by default we process the SDM. If we do not want to, set this flag
+        parser.add_argument('--skip-sdm', action='store_true',
+                            help='Set this flag to avoid collecting SDM records')
+        parser.add_argument('--force-update', action='store_true',
+                            help='Update records if they already exist')
+        parser.add_argument('--logdir', default=None,
+                            help='altnerate path to output log files')
 
     def handle(self, *args, **options):
-        '''
-        Note the '# pragma: no cover' lines below. This is because we are not
-        yet mocking celery for test coverage
-        '''
-        date_start = self.get_date(options['date_start'])
-        date_end = self.get_date(options['date_end'])
+        site = self.get_site(options)
+        dates = self.get_dates(options)
+        backfill_options = ['skip_sdm', 'force_update', 'logdir']
+        extra_args = dict((key, options[key]) for key in backfill_options)
+        # import pdb; pdb.set_trace()
 
-        experimental = options['experimental']
-
-        print('BEGIN RANGE: Backfilling Figures daily metrics for dates {} to {}'.format(
-            date_start, date_end
-        ))
-
-        # don't pass multiple site ids to tasks
-        site_id = None if not options['site'] else self.get_site_ids(options['site'])
-
-        # populate daily metrics one day at a time for date range
-        for dt in rrule(DAILY, dtstart=date_start, until=date_end):
-
-            print('BEGIN: Backfill Figures daily metrics metrics for: {}'.format(dt))
-
-            kwargs = dict(
-                site_id=site_id,
-                date_for=str(dt),
-                force_update=options['overwrite']
-            )
-
-            if experimental:
-                metrics_func = experimental_populate_daily_metrics
-                del kwargs['site_id']  # not implemented for experimental
-            else:
-                metrics_func = populate_daily_metrics
-
-            if options['no_delay']:
-                metrics_func(**kwargs)
-            else:
-                metrics_func.delay(**kwargs)  # pragma: no cover
-
-            print('END: Backfill Figures daily metrics metrics for: {}'.format(dt))
-
-        print('END RANGE: Backfilling Figures daily metrics for dates {} to {}'.format(
-            date_start, date_end
-        ))
+        for date_for in dates:
+            print('Generating daily metrics for date: {}'.format(date_for.isoformat()))
+            results = self.do_backfill(site=site,
+                                       date_for=date_for,
+                                       **extra_args)
+            print('Finished date {}. Processed {} courses'.format(
+                date_for.isoformat(), results['courses_processed']))
+            print('Wrote log file: "{}"'.format(results['logfile']))
+            print('CDM processing time: {}, SDM processing time: {}'.format(
+                results['cdm_elapsed'], results['sdm_elapsed']))

--- a/figures/management/commands/backfill_figures_daily_metrics.py
+++ b/figures/management/commands/backfill_figures_daily_metrics.py
@@ -37,7 +37,6 @@ class Command(BaseCommand):
         logdir = kwargs.get('logdir', None)
         force_update = kwargs.get('force_update', False)
 
-        return 'nop'
         return backfill_daily_metrics_for_site_and_date(site,
                                                         date_for,
                                                         process_sdm=process_sdm,
@@ -106,4 +105,4 @@ class Command(BaseCommand):
                 date_for.isoformat(), results['courses_processed']))
             print('Wrote log file: "{}"'.format(results['logfile']))
             print('CDM processing time: {}, SDM processing time: {}'.format(
-                results['cdm_elapsed'], results['sdm_elapsed']))
+                results['cdms_elapsed'], results['sdm_elapsed']))

--- a/figures/pipeline/backfill.py
+++ b/figures/pipeline/backfill.py
@@ -4,19 +4,53 @@ Initially developed to support API performance improvements
 """
 
 from __future__ import absolute_import
+import os
+from time import time
 from datetime import datetime
 from dateutil.rrule import rrule, MONTHLY
 from dateutil.relativedelta import relativedelta
 
+from django.conf import settings
 from django.utils.timezone import utc
 
 from figures.compat import CourseNotFound
+from figures.course import Course
+from figures.helpers import as_date
+from figures.models import EnrollmentData
 from figures.sites import (
     get_course_enrollments_for_site,
+    get_course_keys_for_site,
     get_student_modules_for_site
 )
+from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader
+from figures.pipeline.site_daily_metrics import SiteDailyMetricsLoader
 from figures.pipeline.site_monthly_metrics import fill_month
-from figures.models import EnrollmentData
+
+# Backfill is done irregularly on an as-needed basis and not part of regularly
+# scheduled operations.
+# Default to a directory for which the edxapp user already has permissions
+# This is an interim implementation is for expediency. We can then follow up
+# with discussion on where a more ideal location would be. Perhaps in
+# `/edx/var/log/figures`. However, the `/edx/var/log` directory does not have
+# write permission for the `edxapp` or `www-data` users, while `/edx/app/edxapp`
+# does. Therefore we initally declar the following to write backfill logs
+DEFAULT_FIGURES_BACKFILL_LOG_DIR = '/edx/app/edxapp/figures/logs/'
+
+
+class InvalidDataError(Exception):
+    """Raised when wrong data are used, like cross-site data processing
+
+    Initially created to raise an exception if cached data or data provided as
+    function parameters do not belong to the site being processed.
+    """
+    pass
+
+
+def figures_backfill_log_dir():
+    """Specify where to write Figures backfill log files
+    """
+    return settings.ENV_TOKENS['FIGURES'].get('BACKFILL_LOG_DIR',
+                                              DEFAULT_FIGURES_BACKFILL_LOG_DIR)
 
 
 # This function called just by mgmt command, backfill_figures_monthly_metrics.py
@@ -86,3 +120,136 @@ def backfill_enrollment_data_for_site(site):
                                      ce_id=rec.id))
 
     return dict(results=enrollment_data, errors=errors)
+
+
+def get_courses_first_enrollment_timestamps(site, as_strings=False):
+    """Return dict of course_id and first enrolled on date
+    key is the course_id, value is the date of the first enrollment
+
+    The dict returned by this function is used to determine which courses need
+    to be backfilled for a given date.
+
+    We have this as a seperate function so that the caller can generate the
+    mapping once to process over a set of days
+
+    The `as_strings` param is used to make it easier to serialize the data to
+    file
+    """
+    data = dict()
+    for course_key in get_course_keys_for_site(site):
+        created = Course(course_key).first_enrollment_timestamp()
+        if as_strings:
+            data[str(course_key)] = created.isoformat()
+        else:
+            data[course_key] = created
+    return data
+
+
+def courses_enrolled_on_or_before(site, date_for, data=None):
+    """list courses that have enrollments created on or befor the date
+    if data is passed in, assumes the date values are `datetime.date`
+
+    For the time being, this is a "getter" function instead of a generator so
+    that we can fail before updating Figures course daily metrics records in
+    the event that a set of data contain courses that do not belong to the site
+    """
+    check_course_ids = get_course_keys_for_site(site)
+    if data is None:
+        data = get_courses_first_enrollment_timestamps(site)
+    date_for = as_date(date_for)
+    course_ids = []
+    for course_id, created in data.items():
+        if course_id not in check_course_ids:
+            msg = 'Aborting: "Course {course_id}" does not belong to site "{domain}"'
+            raise InvalidDataError(msg.format(course_id=str(course_id),
+                                              domain=site.domain))
+
+        # if not created, then there are no enrollments in the course and we skip it
+        if created and as_date(created) <= date_for:
+            course_ids.append(course_id)
+    return course_ids
+
+
+def backfill_daily_metrics_for_site_and_date(site,
+                                             date_for,
+                                             process_sdm=True,
+                                             logdir=None,
+                                             force_update=False):
+    """To be run by Django management command or in Django shell
+
+    To note, this function was originally an ad-hoc script.
+
+    This function creates `CourseDailyMetrics` records for each course for the
+    specified site and day. It then creates the `SiteDailyMetrics` record for
+    the site and day.
+
+    Progress is tracked in a log file with the default directory in this
+    module's `DEFAULT_FIGURES_BACKFILL_LOG_DIR` variable. This can be overriden
+    in the settings "server-vars" file, like so:
+
+    ```
+    EDXAPP_ENV_EXTRA:
+      FIGURES:
+        BACKFILL_LOG_DIR: '/alternate/path/to/figures/backfill/logs'
+    ```
+
+    ## On progress
+
+    Progress will only be updated if we run backfill for the previous calendar
+    day. This is a bit of combined feature of Figures pipeline code and a
+    limitation in that there's not a ready way to extract historical progress
+    for a learner "on this date in the past".
+    """
+    date_for = as_date(date_for)
+    date_for_str = date_for.isoformat()
+
+    if logdir is None:
+        logdir = figures_backfill_log_dir()
+
+    filename = 'backfill-for-site-{site_id}-date-{date_for}.log'.format(
+        site_id=site.id, date_for=date_for_str)
+    filepath = os.path.join(logdir, filename)
+
+    course_ids = courses_enrolled_on_or_before(site, date_for)
+    course_id_count = len(course_ids)
+
+    with open(filepath, 'a', encoding='utf-8') as logfile:
+        start_time = time()
+        logfile.write('START: backfill {} courses, date_for: {}\n'.format(
+            course_id_count, date_for_str))
+        for i, course_id in enumerate(course_ids):
+            logfile.write('[{} of {}] date_for: {}, {}\n'.format(
+                i+1, course_id_count, date_for_str, str(course_id)))
+
+            cdm_obj, _created = CourseDailyMetricsLoader(
+                str(course_id)).load(date_for=date_for, force_update=force_update)
+            logfile.write('-- wrote CDM id: {}\n'.format(cdm_obj.id))
+
+            # We flush so we can tail the log file for progress
+            logfile.flush()
+        cdms_elapsed = time() - start_time
+        logfile.write('\nEND: backfill courses. date_for:{}, elapsed: {}\n'.format(
+            date_for_str, cdms_elapsed))
+        if process_sdm:
+            # TODO: if the SDM already exists, report it. This means the admin
+            # can decide to manually force update, which is usually what we
+            # want, however, we don't want surprise modifications of existing
+            # data, so we're leaving it up to the caller to explicitly say
+            # "destroy and rewrite"
+            logfile.write('START: backfill site {} for date {}: \n'.format(
+                site.domain, date_for_str))
+            start_time = time()
+            sdm_obj, _created = SiteDailyMetricsLoader().load(site=site,
+                                                              date_for=date_for,
+                                                              force_update=force_update)
+            logfile.write('-- wrote SDM id: {}\n'.format(sdm_obj.id))
+            sdm_elapsed = time() - start_time
+            logfile.write('\nEND: backfill site. date_for: {}, elapsed: {}\n'.format(
+                date_for_str, sdm_elapsed))
+
+    # return location of logfile and some instrumentation data
+    return dict(
+        logfile=filepath,
+        courses_processed=course_id_count,
+        cdms_elapsed=cdms_elapsed,
+        sdm_elapsed=sdm_elapsed)

--- a/figures/pipeline/backfill.py
+++ b/figures/pipeline/backfill.py
@@ -213,6 +213,12 @@ def backfill_daily_metrics_for_site_and_date(site,
     course_ids = courses_enrolled_on_or_before(site, date_for)
     course_id_count = len(course_ids)
 
+    # The log file has the site id and date for as identifiers
+    # We have the log file in append mode so that we don't overwrite the existing
+    # file in case something fails, we can pick up the logging in the same file
+    # when restarting the backfill for the same site and date
+    # if we find doing the log file in append more some kind of pain point, we
+    # can improve the engineering then
     with open(filepath, 'a', encoding='utf-8') as logfile:
         start_time = time()
         logfile.write('START: backfill {} courses, date_for: {}\n'.format(

--- a/tests/commands/test_backfill_figures_daily_metrics_command.py
+++ b/tests/commands/test_backfill_figures_daily_metrics_command.py
@@ -1,0 +1,93 @@
+"""Test Figures Django management command, 'backfill_figures_daily_metrics'
+"""
+from __future__ import absolute_import
+import pytest
+
+try:
+    from unittest import mock
+except ImportError:
+    # for Python 2.7
+    import mock
+
+from django.core.management import call_command
+
+from figures.helpers import as_date
+
+from tests.factories import SiteFactory
+
+
+@pytest.mark.django_db
+class TestBackfillDailyMetricsCommand(object):
+
+    MANAGEMENT_COMMAND = 'backfill_figures_daily_metrics'
+    CMD_FULL_PATH = 'figures.management.commands.{}'.format(MANAGEMENT_COMMAND)
+    MOCK_PATH = CMD_FULL_PATH + '.backfill_daily_metrics_for_site_and_date'
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db, settings):
+        self.site = SiteFactory()
+
+        # What we set the mocked func to return
+        self.mock_ret_val = dict(
+            logfile='fale-logfile',
+            courses_processed=42,
+            cdms_elapsed=3.14159,
+            sdm_elapsed=2.71828)
+
+    @pytest.mark.parametrize('site_identifier', ['domain', 'id'])
+    def test_one_day(self, monkeypatch, site_identifier):
+        """Run command for single site and date
+        """
+
+        # What we pass as CLI kwargs
+        cmd_kwargs = dict(
+            date='2021-03-15',
+            skip_sdm=False,
+            force_update=False,
+            logdir=None)
+
+        # What we expect to be passed to the pipeline.bakfill function as kwargs
+        expected_kwargs = dict(
+            process_sdm=True,
+            logdir=None,
+            force_update=False)
+
+        with mock.patch(self.MOCK_PATH) as mock_func:
+            mock_func.resturn_value = self.mock_ret_val
+            call_command(self.MANAGEMENT_COMMAND,
+                         str(getattr(self.site, site_identifier)),
+                         **cmd_kwargs)
+            mock_func.assert_called_once_with(self.site,
+                                              as_date(cmd_kwargs['date']),
+                                              **expected_kwargs)
+
+    @pytest.mark.parametrize('site_identifier', ['domain', 'id'])
+    def test_date_range(self, monkeypatch, site_identifier):
+        """Run command with start and end date range
+        """
+
+        # What we pass as CLI kwargs
+        cmd_kwargs = dict(
+            date_range=['2021-03-15', '2021-03-17'],
+            skip_sdm=False,
+            force_update=False,
+            logdir=None)
+
+        # What we expect to be passed to the pipeline.bakfill function as kwargs
+        expected_kwargs = dict(
+            process_sdm=True,
+            logdir=None,
+            force_update=False)
+
+        expected_calls = [
+            mock.call(self.site, as_date('2021-03-15'), **expected_kwargs),
+            mock.call(self.site, as_date('2021-03-16'), **expected_kwargs),
+            mock.call(self.site, as_date('2021-03-17'), **expected_kwargs),
+        ]
+
+        with mock.patch(self.MOCK_PATH) as mock_func:
+            mock_func.return_value = self.mock_ret_val
+            call_command(self.MANAGEMENT_COMMAND,
+                         str(getattr(self.site, site_identifier)),
+                         **cmd_kwargs)
+            mock_func.assert_has_calls(expected_calls)

--- a/tests/pipeline/test_backfill_daily_metrics.py
+++ b/tests/pipeline/test_backfill_daily_metrics.py
@@ -81,6 +81,7 @@ class TestBackfillDailyMetricsForSiteAndDate(object):
                 site=self.site,
                 date_for=date_for)
 
+        # If this fails, check the write mode
         open_mock.assert_called_with(results['logfile'], 'a', encoding='utf-8')
 
         # For now, we're just basic that records were created for the expected

--- a/tests/pipeline/test_backfill_daily_metrics.py
+++ b/tests/pipeline/test_backfill_daily_metrics.py
@@ -1,0 +1,123 @@
+"""Tests figures.pipeline.backfill historic daily metrics backfill functionality
+
+These functions are tested when `backfill_daily_metrics_for_site_and_date` is called:
+
+* `get_courses_first_enrollment_timestamps`
+* `courses_enrolled_on_or_before`
+"""
+
+from __future__ import absolute_import
+import pytest
+
+try:
+    from unittest import mock
+except ImportError:
+    # for Python 2.7
+    import mock
+
+from figures.helpers import as_date, as_datetime
+from figures.models import CourseDailyMetrics, SiteDailyMetrics
+from figures.pipeline.backfill import (
+
+    backfill_daily_metrics_for_site_and_date
+)
+
+from tests.factories import (
+    CourseOverviewFactory,
+    CourseEnrollmentFactory,
+    SiteFactory,
+)
+
+
+@pytest.mark.django_db
+class TestBackfillDailyMetricsForSiteAndDate(object):
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db, settings):
+        self.site = SiteFactory()
+
+    def test_happy_case(self, monkeypatch):
+        """Make sure it works when everything is good
+
+        This test expects two courses to be processed and one course skipped
+        """
+        date_for = as_date('2022-01-01')
+        course_overviews = [CourseOverviewFactory(),
+                            CourseOverviewFactory(),
+                            CourseOverviewFactory()]
+
+        # Enrollments for the first course
+        # Both enrollments created before the "date_for" date
+        CourseEnrollmentFactory(course_id=course_overviews[0].id,
+                                created=as_datetime('2020-05-15'))
+        CourseEnrollmentFactory(course_id=course_overviews[0].id,
+                                created=as_datetime('2020-06-15'))
+
+        # Enrollments for the second course
+        # One enrollment created before the "date_for" date and one after
+        CourseEnrollmentFactory(course_id=course_overviews[1].id,
+                                created=as_datetime('2021-05-15'))
+        # This one shouldn't show up in the CDM record
+        CourseEnrollmentFactory(course_id=course_overviews[1].id,
+                                created=as_datetime('2022-02-15'))
+
+        # Enrollment for the third course
+        # This enrollment created after the "date_for" date
+        # A CDM record should not be created for this course
+        CourseEnrollmentFactory(course_id=course_overviews[2].id,
+                                created=as_datetime('2022-02-15'))
+
+        assert CourseDailyMetrics.objects.count() == 0
+        assert SiteDailyMetrics.objects.count() == 0
+
+        open_mock = mock.mock_open()
+
+        monkeypatch.setattr('figures.pipeline.backfill.get_course_keys_for_site',
+                            lambda site: [obj.id for obj in course_overviews])
+        monkeypatch.setattr('figures.pipeline.course_daily_metrics.figures.sites.get_site_for_course',
+                            lambda course_id: self.site)
+        with mock.patch('figures.pipeline.backfill.open', open_mock):
+            results = backfill_daily_metrics_for_site_and_date(
+                site=self.site,
+                date_for=date_for)
+
+        open_mock.assert_called_with(results['logfile'], 'a', encoding='utf-8')
+
+        # For now, we're just basic that records were created for the expected
+        # courses and site. Metrics values are tested in other tests
+        found_course_ids = CourseDailyMetrics.objects.values_list('course_id', flat=True)
+        expected_course_ids = [str(obj.id) for obj in course_overviews[:2]]
+        assert set(found_course_ids) == set(expected_course_ids)
+        assert SiteDailyMetrics.objects.count() == 1
+        assert SiteDailyMetrics.objects.first().site == self.site
+
+    def test_empty_case(self, monkeypatch):
+        """Make sure it works when everything is good
+
+        This test expects two courses to be processed and one course skipped
+        """
+        date_for = as_date('2022-01-01')
+        course_overviews = [CourseOverviewFactory(),
+                            CourseOverviewFactory(),
+                            CourseOverviewFactory()]
+
+        assert CourseDailyMetrics.objects.count() == 0
+        assert SiteDailyMetrics.objects.count() == 0
+
+        open_mock = mock.mock_open()
+
+        monkeypatch.setattr('figures.pipeline.backfill.get_course_keys_for_site',
+                            lambda site: [obj.id for obj in course_overviews])
+
+        with mock.patch('figures.pipeline.backfill.open', open_mock):
+            results = backfill_daily_metrics_for_site_and_date(
+                site=self.site,
+                date_for=date_for)
+
+        open_mock.assert_called_with(results['logfile'], 'a', encoding='utf-8')
+
+        # For now, we're just basic that records were created for the expected
+        # courses and site. Metrics values are tested in other tests
+        assert CourseDailyMetrics.objects.count() == 0
+        assert SiteDailyMetrics.objects.count() == 1
+        assert SiteDailyMetrics.objects.first().site == self.site

--- a/tests/pipeline/test_course_daily_metrics.py
+++ b/tests/pipeline/test_course_daily_metrics.py
@@ -10,11 +10,11 @@ import pytest
 
 from dateutil.relativedelta import relativedelta
 
-from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.exceptions import ValidationError
 
 from figures.compat import CourseAccessRole, CourseEnrollment
 from figures.helpers import as_datetime, next_day, prev_day
-from figures.models import CourseDailyMetrics, PipelineError
+from figures.models import CourseDailyMetrics
 from figures.pipeline import course_daily_metrics as pipeline_cdm
 import figures.sites
 
@@ -85,13 +85,21 @@ class TestCourseDailyMetricsPipelineFunctions(object):
     @pytest.fixture(autouse=True)
     def setup(self, db):
         self.today = datetime.date(2018, 6, 1)
+        self.enrollment_dates = [
+            '2018-04-27', '2018-04-28', '2018-04-29', '2018-04-30'
+        ]
+
         self.course_overview = CourseOverviewFactory()
         if OPENEDX_RELEASE == GINKGO:
             self.course_enrollments = [CourseEnrollmentFactory(
-                course_id=self.course_overview.id) for i in range(4)]
+                course_id=self.course_overview.id,
+                created=as_datetime(dt)
+                ) for dt in self.enrollment_dates]
         else:
             self.course_enrollments = [CourseEnrollmentFactory(
-                course=self.course_overview) for i in range(4)]
+                course=self.course_overview,
+                created=as_datetime(dt)
+                ) for dt in self.enrollment_dates]
 
         if organizations_support_sites():
             self.my_site = SiteFactory(domain='my-site.test')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 
-from dateutil import parser
 import mock
 import pytest
 
@@ -28,7 +27,7 @@ class TestBaseBackfillCommand(object):
     ])
     def test_get_side_ids(self, site, expected_result):
         """Test that get_site_ids will return the correct Site id if passed that id
-        or the corresponding Site's domain, will return all Site ids if none passed, 
+        or the corresponding Site's domain, will return all Site ids if none passed,
         and will return an empty list if a non-existing Site id or domain passed
         """
         # Site table will have an existing example.com Site as well as whatever we
@@ -41,81 +40,6 @@ class TestBaseBackfillCommand(object):
             mock_get_sites.return_value = [example_site, site1, site2]
             site_ids = BaseBackfillCommand().get_site_ids(site)
             assert site_ids == expected_result
-
-
-@pytest.mark.django_db
-class TestBackfillDailyMetrics(object):
-    """Exercise backfill_figures_daily_metrics command."""
-
-    BASE_PATH = 'figures.management.commands.backfill_figures_daily_metrics'
-    PLAIN_PATH = BASE_PATH + '.populate_daily_metrics'
-    DELAY_PATH = PLAIN_PATH + '.delay'
-    EXP_PATH = BASE_PATH + '.experimental_populate_daily_metrics'
-
-    def test_backfill_daily_func(self):
-        """Test backfill daily regular and experimental.
-        """
-        with mock.patch(self.PLAIN_PATH) as mock_populate:
-            call_command('backfill_figures_daily_metrics', no_delay=True)
-            mock_populate.assert_called()
-        with mock.patch(self.EXP_PATH) as mock_populate_exp:
-            call_command('backfill_figures_daily_metrics', experimental=True, no_delay=True)
-            mock_populate_exp.assert_called()
-
-    def test_backfill_daily_delay(self):
-        """Test backfill daily called without no_delay uses Celery task delay.
-        """
-        with mock.patch(self.DELAY_PATH) as mock_populate:
-            call_command('backfill_figures_daily_metrics')
-            mock_populate.assert_called()
-
-    def test_backfill_daily_dates(self):
-        """Test backfill daily called with start and end dates
-        """
-        end = '2021-06-08'
-        start = '2021-01-01'
-        start_dt = parser.parse(start)
-        end_dt = parser.parse(end)
-        exp_days = abs((end_dt - start_dt).days) + 1
-        with mock.patch(self.PLAIN_PATH) as mock_populate:
-            call_command(
-                'backfill_figures_daily_metrics', 
-                date_start=start, date_end=end, no_delay=True
-            )
-            assert mock_populate.call_count == exp_days
-
-    def test_backfill_daily_same_day(self):
-        """Test backfill daily called with same start and end date.
-        """
-        start = '2021-06-08'
-        end = '2021-06-08'
-        exp_days = 1
-        with mock.patch(self.PLAIN_PATH) as mock_populate:
-            call_command(
-                'backfill_figures_daily_metrics', 
-                date_start=start, date_end=end, no_delay=True
-            )
-            assert mock_populate.call_count == exp_days
-
-    def test_backfill_daily_with_site_id(self):
-        """Test that proper site id gets passed to task func when passing integer."""
-        with mock.patch(self.PLAIN_PATH) as mock_populate:
-            call_command('backfill_figures_daily_metrics', site=1, no_delay=True)
-            assert mock_populate.called_with(site_id=1)
-
-    def test_backfill_daily_with_site_domain(self):
-        """Test that proper site id gets passed to task func when passing integer."""
-        SiteFactory.reset_sequence(0)
-        site2 = SiteFactory()  # site-0.example.com
-        with mock.patch(self.PLAIN_PATH) as mock_populate:
-            call_command('backfill_figures_daily_metrics', site="site-0.example.com", no_delay=True)
-            assert mock_populate.called_with(site_id=2)
-
-    def test_backfill_daily_without_site_id(self):
-        """Test that proper site id gets passed to task func when passing integer."""
-        with mock.patch(self.PLAIN_PATH) as mock_populate:
-            call_command('backfill_figures_daily_metrics', no_delay=True)
-            assert mock_populate.called_with(site_id=None)
 
 
 class TestPopulateFiguresMetricsCommand(object):
@@ -150,7 +74,8 @@ class TestPopulateFiguresMetricsCommand(object):
     def test_correct_subtitute_commands_called(self, options, subst_command, subst_call_options):
         old_pop_cmd = 'figures.management.commands.populate_figures_metrics.call_command'
         with mock.patch(old_pop_cmd) as mock_call_cmd:
-            call_command('populate_figures_metrics', **options)  # this isn't the patched version of call_command
+            # this isn't the patched version of call_command
+            call_command('populate_figures_metrics', **options)
             mock_call_cmd.assert_called_with(subst_command, **subst_call_options)
 
 
@@ -178,7 +103,8 @@ class TestBackfillFiguresMetricsCommand(object):
     def test_correct_subtitute_commands_called(self, options, subst_call_options):
         old_pop_cmd = 'figures.management.commands.backfill_figures_metrics.call_command'
         with mock.patch(old_pop_cmd) as mock_call_cmd:
-            call_command('backfill_figures_metrics', **options)  # this isn't the patched version of call_command
+            # this isn't the patched version of call_command
+            call_command('backfill_figures_metrics', **options)
             dailycmd = 'backfill_figures_daily_metrics'
             monthlycmd = 'backfill_figures_monthly_metrics'
             mock_call_cmd.assert_any_call(dailycmd, **subst_call_options)

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -120,9 +120,26 @@ class TestCourse(object):
         assert set(found_ce) == set(ce[:2])
 
     def test_enrollments_with_student_modules_but_no_student_modules(self):
-        ce = [CourseEnrollmentFactory(course_id=self.course_overview.id)
-              for _ in range(3)]
+        [CourseEnrollmentFactory(course_id=self.course_overview.id)
+         for _ in range(3)]
 
         course = Course(self.course_overview.id)
         assert not course.student_modules
         assert not course.enrollments_with_student_modules()
+
+    def test_first_enrollment_timestamp_without_enrollments(self):
+        course = Course(self.course_overview.id)
+        assert course.first_enrollment_timestamp() is None
+
+    def test_first_enrollment_timestamp_with_enrollments(self):
+        ce = [CourseEnrollmentFactory(course_id=self.course_overview.id)
+              for _ in range(3)]
+        dates = sorted([rec.created for rec in ce])
+
+        # Make sure we don't have duplicates
+        # If this assertion ever fails, go revisit the `created` field assignment
+        # for CourseEnrollmentFactory
+        assert len(set(dates)) == len(dates)
+
+        course = Course(self.course_overview.id)
+        assert course.first_enrollment_timestamp() == dates[0]


### PR DESCRIPTION
https://appsembler.atlassian.net/browse/BLACK-2375

Porting ad-hoc scripts into Figures to fill approximate metrics for historical values

There should be one more commit, modify the existing Django management command, `backfill_figures_daily_metrics` and add test coverage for that command

## Commit 8aeced479a0949eef179c24ed17b5db2707e8d46

Add method - figures.course.Course.first_enrollment_timestamp

This exists to help identify when we should include a course in
performing backfill to `CourseDailyMetrics` for a given date in the
past.

Getting the `CourseEnrollment.created` value for the first enrollment
provides a fast "close enough best guess" when a course was first
created, as we cannot rely on CourseOverview timestamps and this avoids
diving into MongoDB or the filesystem to dredge up timestamps for the
given course

## Commit  7146aa49153ee7ecf69be1eba09ea6246ba296f1

Commit message has the important details, but here's a brief summary:

This one fixes a latent bug in an existing test case that appeared because the test case did not explicitly set course enrollment 'created' dates for the `CourseEnrollmentFactory` instantiations. After we added new CourseEnrollmentFactory created instances, the `created` date got bumped past the date check. 

## Commit 8aeced479a0949eef179c24ed17b5db2707e8d46

New functions to call backfill for a site and date and track the backfill to a log file

## Commit 0fa88808f6e166f10016a61959aaf66270898cc4

Add new test module, remove test class from old test module

