### PR TITLE
Bump juniper devsite Django to 2.2.28

### DIFF
--- a/devsite/requirements/juniper_base.txt
+++ b/devsite/requirements/juniper_base.txt
@@ -24,7 +24,7 @@ pytz==2020.1
 ## Django package dependencies
 ##
 
-Django==2.2.27
+Django==2.2.28
 
 djangorestframework==3.9.4
 django-countries==5.5


### PR DESCRIPTION
Because Dependabot posted this PR: https://github.com/appsembler/figures/pull/454

