### PR TITLE
Fix broken devsite data seeding

### DIFF
--- a/devsite/devsite/seed.py
+++ b/devsite/devsite/seed.py
@@ -25,7 +25,7 @@ from student.models import CourseAccessRole, CourseEnrollment, UserProfile
 
 from organizations.models import Organization, OrganizationCourse
 
-from figures.backfill import backfill_enrollment_data_for_site
+from figures.pipeline.backfill import backfill_enrollment_data_for_site
 from figures.compat import RELEASE_LINE, GeneratedCertificate
 from figures.models import (
     CourseDailyMetrics,
@@ -166,7 +166,8 @@ def seed_users(data=None):
                     country=profile_rec.get('country', None),
                 )
         except IntegrityError as e:
-            print(('skipping duplicate user email {}'.format(e)))
+            print(('skipping duplicate user email {} for email: {}'.format(
+                e, rec['emailX'])))
     return created_users
 
 

--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -240,10 +240,11 @@ FEATURES = {
     'FIGURES_IS_MULTISITE': env('FIGURES_IS_MULTISITE')
 }
 
-
 # The LMS defines ``ENV_TOKENS`` to load settings declared in `lms.env.json`
-# We have an empty dict here to replicate behavior in the LMS
-ENV_TOKENS = {}
+# We have an (mostly) empty dict here to replicate behavior in the LMS
+ENV_TOKENS = {
+    'FIGURES': {},  # This variable is patched by the Figures' `lms_production.py` settings module.
+}
 
 PRJ_SETTINGS = {
     'CELERY_ROUTES': "app.celery.routes"


### PR DESCRIPTION
* `devsite.seed` was not updated when `figures.backfill` was moved to `figures.pipeline.backfill`. This fixes that issue
* `devsite.settings` needed to have `FIGURES` key preset. This was causing devsite seed to fail too
* Improved the user creation integrity error by displaying the email address. Users are dynamically generated with `Faker` and sometimes the same email address is used. While not strictly needed, it may help the developer experience a little bit by seeing what email generated caused the collision

