### PR TITLE
Fix tasks for standalone and fix average progress validation error

### DIFF
--- a/figures/pipeline/enrollment_metrics_next.py
+++ b/figures/pipeline/enrollment_metrics_next.py
@@ -29,6 +29,7 @@ This module improves on the existing enrollment metrics collection module,
 This module provides
 
 """
+from decimal import Decimal
 from django.db.models import Avg
 from figures.course import Course
 from figures.enrollment import is_enrollment_data_out_of_date
@@ -101,4 +102,7 @@ def calculate_course_progress(course_id):
     # have None for progress if there's no data. But check how SQL AVG performs
     if results['average_progress'] is None:
         results['average_progress'] = 0.0
+    else:
+        rounded_val = Decimal(results['average_progress']).quantize(Decimal('.00'))
+        results['average_progress'] = float(rounded_val)
     return results

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -327,17 +327,25 @@ def get_sites():
     """
     Get a list of sites for Figures purposes in a configurable manner.
 
-    This functions makes use of the `SITES_BACKEND` setting if configured, otherwise
+    :return list of Site (QuerySet)
+
+    For multisite mode, when `settings.FEATURES['FIGURES_IS_MULTISITE'] == True`,
+    this functions makes use of the `SITES_BACKEND` setting if configured, otherwise
     it defaults to  _get_all_sites().
 
-    :return list of Site (QuerySet)
+    For standalone mode, the default site is returned as the single record in
+    the QuerySet result
     """
-    sites_backend_path = settings.ENV_TOKENS['FIGURES'].get('SITES_BACKEND')
-    if sites_backend_path:
-        sites_backend = import_from_path(sites_backend_path)
-        sites = sites_backend()
+    if is_multisite():
+        sites_backend_path = settings.ENV_TOKENS['FIGURES'].get('SITES_BACKEND')
+        if sites_backend_path:
+            sites_backend = import_from_path(sites_backend_path)
+            sites = sites_backend()
+        else:
+            sites = _get_all_sites()
     else:
-        sites = _get_all_sites()
+        # We do the filter so that we are returning a QuerySet object
+        sites = Site.objects.filter(id__in=[default_site().id])
 
     return sites
 

--- a/tests/tasks/test_mau_tasks.py
+++ b/tests/tasks/test_mau_tasks.py
@@ -81,6 +81,8 @@ def test_populate_all_mau_multiple_site(transactional_db, monkeypatch):
     def mock_populate_mau_metrics_for_site(site_id, force_update=False):
         sites_visited.append(site_id)
 
+    monkeypatch.setattr('figures.sites.is_multisite', lambda: True)
+    monkeypatch.setattr('figures.tasks.is_multisite', lambda: True)
     monkeypatch.setattr('figures.tasks.populate_mau_metrics_for_site',
                         mock_populate_mau_metrics_for_site)
 

--- a/tests/views/test_sites_view.py
+++ b/tests/views/test_sites_view.py
@@ -44,7 +44,8 @@ class TestSiteViewSet(BaseViewTest):
         ('?domain=bravo', {'domain__icontains': 'bravo'}),
         ('?name=alpha', {'name__icontains': 'alpha'})
         ])
-    def test_get(self, query_params, filter_args):
+    def test_get(self, monkeypatch, query_params, filter_args):
+        monkeypatch.setattr('figures.sites.is_multisite', lambda: True)
         qp_msg = 'query_params={query_params}'
         expected_data = Site.objects.filter(**filter_args)
         request = APIRequestFactory().get(self.request_path + query_params)


### PR DESCRIPTION
https://appsembler.atlassian.net/browse/BLACK-2554

## Fix average progress validation error

The problem was that the new pipeline workflow did not round enrollments' "progress percent" when averaging for CourseDailyMetrics average_progress fixed floating point field. This commit addresses this

## Fix site handling for standalone mode

This commit makes figures.sites.get_sites aware of standalone mode. The purpose of this is to help make standalone and multisite modes transparent to the bulk of Figures code
    
There are also a couple of minor changes in figures.tasks
    
1. populate_daily_metrics_next now includes the exception string to the error log entry
2. run_figures_monthly_metrics is now standalone aware. Since only one site is run for standalone, there's no need to spawn the site level function as a subtask

After this PR, I'll  do a PR bump for version to 0.4.3 