### PR TITLE
Update general courses ordering_fields attribute to allow ordering by start date

### DIFF
--- a/figures/views.py
+++ b/figures/views.py
@@ -217,7 +217,7 @@ class GeneralCourseDataViewSet(CourseOverviewViewSet):
     pagination_class = FiguresKiloPagination
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
     search_fields = ['display_name', 'id']
-    ordering_fields = ['display_name', 'self_paced', 'date_joined']
+    ordering_fields = ['display_name', 'self_paced', 'date_joined', 'start_date']
 
 
 class CourseDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):

--- a/figures/views.py
+++ b/figures/views.py
@@ -217,7 +217,7 @@ class GeneralCourseDataViewSet(CourseOverviewViewSet):
     pagination_class = FiguresKiloPagination
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
     search_fields = ['display_name', 'id']
-    ordering_fields = ['display_name', 'self_paced', 'date_joined', 'start_date']
+    ordering_fields = ['display_name', 'self_paced', 'start_date']
 
 
 class CourseDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
## Change description

Update general courses ordering_fields attribute to allow ordering by start date.

I’m looking to add course sorting in the dashboard by course start date. Currently sorting is possible by course name (display_name) and pacing (self_paced). Current sorting options are done at the figures API level (figures/api/course-general/). Since start_date is [already defined](https://github.com/appsembler/figures/blob/6f3202845a54c1f1310dc715f4400de0d66d1e00/figures/serializers.py#L273) in the serializer, I believe start_date just needs to be [added to the ordering_fields attribute](https://www.django-rest-framework.org/api-guide/filtering/#specifying-which-fields-may-be-ordered-against).

Also, date_joined is in the ordering_fields attribute, but it's not defined in GeneralCourseDataSerializer and returns a 500 error in Postman. I believe this was mistakingly added from the User/Learner serializers ([e.g.](https://github.com/appsembler/figures/blob/6f3202845a54c1f1310dc715f4400de0d66d1e00/figures/serializers.py#L505)).

New to Python and Django though, so correct me if I'm wrong anywhere.

## Type of change
- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
